### PR TITLE
Persist admin login state

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -44,15 +44,14 @@
       const user = document.getElementById('username').value;
       const pass = document.getElementById('password').value;
 
-      if (user === 'admin' && pass === 'admin') {
-        console.log(localStorage.getItem('isAdmin'));
-		console.log("Trying to log in", user, pass);
-		console.log("Redirecting to Projects.html...");
-        window.location.href = 'Projects.html'; // or dashboard.html
-      } else {
-        document.getElementById('error-message').textContent = 'Invalid credentials';
+        if (user === 'admin' && pass === 'admin') {
+          // Persist admin status so restricted features can be enabled
+          localStorage.setItem('isAdmin', 'true');
+          window.location.href = 'Projects.html'; // or dashboard.html
+        } else {
+          document.getElementById('error-message').textContent = 'Invalid credentials';
+        }
       }
-    }
-  </script>
-</body>
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure admin login sets `isAdmin` flag in localStorage so privileged features become accessible across pages

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688fbf9dcab8832e982b6fa2a5e62048