### PR TITLE
Enable inline editing on Projects page

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -21,6 +21,7 @@ header {
   align-items: flex-start;
   padding: 20px 40px 30px 40px;
   flex-wrap: nowrap;
+  position: relative;
 }
 header h1 {
   font-size: 2rem;
@@ -51,6 +52,19 @@ nav a:hover {
   color: white;
   transform: translateY(-6px);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.15);
+}
+
+.edit-icon {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+body.editing .project-card {
+  border: 2px dashed black;
+  cursor: move;
 }
 
 /* Project Grid */

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -8,14 +8,6 @@
 <body>
   <!-- Header will be injected here -->
   <div id="site-header"></div>
-  <script>
-    fetch('../header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
-  </script>
-
   <main>
     <div class="projects-grid" id="projects-container"></div>
   </main>
@@ -23,52 +15,88 @@
   <script>
     const isAdmin = localStorage.getItem('isAdmin') === 'true';
 
+    fetch('../header.html')
+      .then(res => res.text())
+      .then(data => {
+        document.getElementById('site-header').innerHTML = data;
+        if (isAdmin) {
+          const icon = document.getElementById('edit-icon');
+          if (icon) {
+            icon.style.display = 'block';
+            icon.addEventListener('click', () => {
+              document.body.classList.toggle('editing');
+              renderProjects();
+            });
+          }
+        }
+      });
+
+    let projectEntries = [];
+    const container = document.getElementById('projects-container');
+    let draggedIndex = null;
+
+    function renderProjects() {
+      container.innerHTML = '';
+      projectEntries.forEach(([projectKey, images]) => {
+        if (images.length === 0) return;
+        const thumbnail = `${projectKey}/Images/${images[0].filename}`;
+        const card = document.createElement('a');
+        card.href = `${projectKey}/${projectKey}.html`;
+        card.className = 'project-card';
+        card.innerHTML = `
+          <img src="${thumbnail}" alt="${images[0].title}">
+          <div class="project-title">${projectKey.replace(/_/g, ' ')}</div>
+        `;
+        if (document.body.classList.contains('editing')) {
+          card.setAttribute('draggable', true);
+        }
+        container.appendChild(card);
+      });
+    }
+
     fetch('../all-projects.json')
       .then(response => response.json())
-      .then(projectsData => {
-        const container = document.getElementById('projects-container');
-
-        Object.entries(projectsData).forEach(([projectKey, images]) => {
-          if (images.length === 0) return;
-
-          // Use the first image as thumbnail
-          const thumbnail = `${projectKey}/Images/${images[0].filename}`;
-          const card = document.createElement('a');
-          card.href = `${projectKey}/${projectKey}.html`;
-          card.className = 'project-card';
-          card.style.position = 'relative';
-
-          card.innerHTML = `
-            <img src="${thumbnail}" alt="${images[0].title}">
-            <div class="project-title" contenteditable="${isAdmin}">${projectKey.replace(/_/g, ' ')}</div>
-            ${isAdmin ? `<button class="edit-button" data-project="${projectKey}">✏️</button>` : ''}
-          `;
-
-          container.appendChild(card);
-        });
-
-        if (isAdmin) {
-          const style = document.createElement('style');
-          style.textContent = `
-            .edit-button {
-              position: absolute;
-              top: 10px;
-              right: 10px;
-              background: rgba(255,255,255,0.9);
-              border: none;
-              cursor: pointer;
-              font-size: 1rem;
-              padding: 4px 8px;
-              border-radius: 6px;
-              z-index: 2;
-            }
-          `;
-          document.head.appendChild(style);
-        }
+      .then(data => {
+        projectEntries = Object.entries(data);
+        renderProjects();
       })
       .catch(error => {
-        console.error("Error loading all-projects.json:", error);
+        console.error('Error loading all-projects.json:', error);
       });
+
+    document.addEventListener('dragstart', e => {
+      if (!e.target.classList.contains('project-card')) return;
+      draggedIndex = [...container.children].indexOf(e.target);
+      e.dataTransfer.effectAllowed = 'move';
+    });
+
+    document.addEventListener('dragover', e => {
+      if (document.body.classList.contains('editing') && e.target.classList.contains('project-card')) {
+        e.preventDefault();
+      }
+    });
+
+    document.addEventListener('drop', e => {
+      if (!document.body.classList.contains('editing') || !e.target.classList.contains('project-card')) return;
+      e.preventDefault();
+      const dropIndex = [...container.children].indexOf(e.target);
+      const [moved] = projectEntries.splice(draggedIndex, 1);
+      projectEntries.splice(dropIndex, 0, moved);
+      renderProjects();
+      saveOrder();
+    });
+
+    function saveOrder() {
+      const ordered = {};
+      projectEntries.forEach(([key, images]) => {
+        ordered[key] = images;
+      });
+      fetch('../save-projects.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(ordered)
+      }).catch(err => console.error('Save failed', err));
+    }
   </script>
 </body>
 </html>

--- a/header.html
+++ b/header.html
@@ -9,6 +9,6 @@
     <a href="/repository/CNC-CutSheet-layout/CNC-CutSheet-layout.html">CNC CutSheet Layout</a>
     <a href="/repository/Contact/Contact.html">Contact</a>
     <a href="/repository/admin.html">Login</a>
-    <a href="/repository/dashboard.html">Dashboard</a>
   </nav>
+  <span id="edit-icon" class="edit-icon" title="Edit" style="display:none;">✏️</span>
 </header>


### PR DESCRIPTION
## Summary
- Replace dashboard link with admin-only pencil icon in header
- Add drag-and-drop editing for Projects page and persist order

## Testing
- `php -l save-projects.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fd0186894832ebd0849ec0b0b2422