### PR TITLE
Add admin project editing and uploads

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -62,6 +62,23 @@ nav a:hover {
   font-size: 1.2rem;
 }
 
+#add-project-btn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid black;
+  background: white;
+  cursor: pointer;
+  display: none;
+  z-index: 1000;
+}
+body.editing #add-project-btn {
+  display: block;
+}
+
 body.editing .project-card {
   border: 2px dashed black;
   cursor: move;
@@ -193,6 +210,25 @@ body.editing .project-card {
   margin-bottom: 60px;
   gap: 40px;
   flex-wrap: wrap;
+}
+.project-section.left {
+  flex-direction: row;
+}
+.project-section.right {
+  flex-direction: row-reverse;
+}
+.project-section.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+.project-section.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.project-section.carousel {
+  display: flex;
+  overflow-x: auto;
+  gap: 20px;
 }
 .project-section img {
   max-width: 50%;

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -34,6 +34,29 @@
     let projectEntries = [];
     const container = document.getElementById('projects-container');
     let draggedIndex = null;
+    if (isAdmin) {
+      const addBtn = document.createElement('button');
+      addBtn.id = 'add-project-btn';
+      addBtn.textContent = '+';
+      addBtn.title = 'Add Project';
+      addBtn.addEventListener('click', () => {
+        const key = prompt('Enter new project identifier (use underscores instead of spaces)');
+        if (!key) return;
+        if (projectEntries.some(([k]) => k === key)) {
+          alert('Project already exists');
+          return;
+        }
+        projectEntries.push([key, []]);
+        renderProjects();
+        saveOrder();
+        fetch('../create-project.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key })
+        }).catch(err => console.error('create-project failed', err));
+      });
+      document.body.appendChild(addBtn);
+    }
 
     function renderProjects() {
       container.innerHTML = '';

--- a/Projects/comprehensive_studio/comprehensive_studio.html
+++ b/Projects/comprehensive_studio/comprehensive_studio.html
@@ -15,78 +15,15 @@
       });
   </script>
 
-  <main class="project-detail">
+  <main class="project-detail" data-project="comprehensive_studio">
     <h2>Comprehensive Studio</h2>
     <p>This project explores architectural infrastructure and public spatial systems through digital and physical modeling, generative diagrams, and construction logic.</p>
-
     <div id="dynamic-project-sections"></div>
+    <div id="admin-tools" style="display:none;">
+      <input type="file" id="image-upload" multiple />
+    </div>
   </main>
 
-  <script>
-    const projectKey = 'comprehensive_studio';
-    const baseImagePath = 'Images/';
-
-    fetch('../../all-projects.json')
-      .then(res => res.json())
-      .then(data => {
-        const images = data[projectKey];
-        const container = document.getElementById('dynamic-project-sections');
-
-        images.forEach(item => {
-          const section = document.createElement('div');
-          section.className = 'project-section';
-
-          section.innerHTML = `
-            <img class="lightbox-image" src="${baseImagePath + item.filename}" alt="${item.title}" />
-            <div class="project-text">
-              <h3>${item.title}</h3>
-              <p>${item.description}</p>
-            </div>
-          `;
-
-          container.appendChild(section);
-        });
-      });
-  </script>
-
-  <!-- Lightbox Script -->
-  <script>
-    document.addEventListener('click', e => {
-      if (e.target.classList.contains('lightbox-image')) {
-        showLightbox(Array.from(document.querySelectorAll('.lightbox-image')), e.target);
-      }
-    });
-
-    function showLightbox(images, activeImage) {
-      let currentIndex = images.indexOf(activeImage);
-
-      const overlay = document.createElement('div');
-      overlay.className = 'lightbox-overlay';
-      overlay.innerHTML = `
-        <span class="close">&times;</span>
-        <span class="nav prev">&#10094;</span>
-        <img src="${activeImage.src}" />
-        <span class="nav next">&#10095;</span>
-      `;
-      document.body.appendChild(overlay);
-
-      const overlayImg = overlay.querySelector('img');
-
-      function updateImage(index) {
-        overlayImg.src = images[index].src;
-        currentIndex = index;
-      }
-
-      overlay.querySelector('.prev').onclick = () => updateImage((currentIndex - 1 + images.length) % images.length);
-      overlay.querySelector('.next').onclick = () => updateImage((currentIndex + 1) % images.length);
-      overlay.querySelector('.close').onclick = () => overlay.remove();
-      overlay.onclick = e => { if (e.target === overlay) overlay.remove(); };
-      document.onkeydown = e => {
-        if (e.key === 'Escape') overlay.remove();
-        if (e.key === 'ArrowLeft') overlay.querySelector('.prev').click();
-        if (e.key === 'ArrowRight') overlay.querySelector('.next').click();
-      };
-    }
-  </script>
+  <script src="../../project-editor.js"></script>
 </body>
 </html>

--- a/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.js
+++ b/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.js
@@ -1,1 +1,0 @@
-document.getElementById('project-gallery').textContent = 'Gallery coming soon.';

--- a/create-project.php
+++ b/create-project.php
@@ -1,0 +1,22 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $key = preg_replace('/[^a-zA-Z0-9_-]/', '', $data['key'] ?? '');
+    if (!$key) {
+        http_response_code(400);
+        echo json_encode(['error' => 'invalid key']);
+        exit;
+    }
+    $dir = "Projects/$key";
+    if (!is_dir($dir)) {
+        mkdir("$dir/Images", 0777, true);
+        $template = file_get_contents('project-template.html');
+        $html = str_replace('{{PROJECT_KEY}}', $key, $template);
+        file_put_contents("$dir/$key.html", $html);
+    }
+    echo json_encode(['status' => 'ok']);
+} else {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+}
+?>

--- a/project-editor.js
+++ b/project-editor.js
@@ -1,0 +1,140 @@
+const isAdmin = localStorage.getItem('isAdmin') === 'true';
+const main = document.querySelector('main.project-detail');
+const projectKey = main.dataset.project;
+const container = document.getElementById('dynamic-project-sections');
+let allProjects = {};
+let images = [];
+let dragIndex = null;
+
+fetch('../../all-projects.json')
+  .then(res => res.json())
+  .then(data => {
+    allProjects = data;
+    images = allProjects[projectKey] || [];
+    render();
+    if (isAdmin) setupAdmin();
+  });
+
+function render() {
+  container.innerHTML = '';
+  images.forEach((img, index) => {
+    const section = document.createElement('div');
+    section.className = 'project-section ' + (img.layout || '');
+    section.draggable = isAdmin;
+    section.dataset.index = index;
+    section.innerHTML = `
+      <img class="lightbox-image" src="Images/${img.filename}" alt="${img.title}">
+      <div class="project-text">
+        <h3 contenteditable="${isAdmin}">${img.title}</h3>
+        <p contenteditable="${isAdmin}">${img.description}</p>
+        ${isAdmin ? `<select class="layout-select">
+            <option value="">Default</option>
+            <option value="left">Left</option>
+            <option value="right">Right</option>
+            <option value="grid-2">Grid 2</option>
+            <option value="grid-3">Grid 3</option>
+            <option value="carousel">Carousel</option>
+          </select>` : ''}
+      </div>
+    `;
+    if (isAdmin) {
+      const sel = section.querySelector('.layout-select');
+      sel.value = img.layout || '';
+      sel.addEventListener('change', e => {
+        images[index].layout = e.target.value;
+        save();
+      });
+      section.querySelector('h3').addEventListener('input', e => {
+        images[index].title = e.target.innerText;
+        save();
+      });
+      section.querySelector('p').addEventListener('input', e => {
+        images[index].description = e.target.innerText;
+        save();
+      });
+      section.addEventListener('dragstart', dragStart);
+      section.addEventListener('dragover', dragOver);
+      section.addEventListener('drop', drop);
+    }
+    container.appendChild(section);
+  });
+}
+
+function setupAdmin() {
+  document.getElementById('admin-tools').style.display = 'block';
+  document.getElementById('image-upload').addEventListener('change', handleUpload);
+}
+
+function handleUpload(e) {
+  const files = [...e.target.files];
+  if (files.length === 0) return;
+  const formData = new FormData();
+  files.forEach(f => formData.append('images[]', f));
+  formData.append('project', projectKey);
+  fetch('../../upload.php', { method: 'POST', body: formData })
+    .then(res => res.json())
+    .then(newItems => {
+      images.push(...newItems);
+      allProjects[projectKey] = images;
+      render();
+      save();
+    });
+}
+
+function dragStart(e) {
+  dragIndex = +this.dataset.index;
+}
+function dragOver(e) {
+  e.preventDefault();
+}
+function drop(e) {
+  e.preventDefault();
+  const dropIndex = +this.dataset.index;
+  if (dragIndex === dropIndex) return;
+  const [moved] = images.splice(dragIndex, 1);
+  images.splice(dropIndex, 0, moved);
+  render();
+  save();
+}
+
+function save() {
+  allProjects[projectKey] = images;
+  fetch('../../save-projects.php', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(allProjects)
+  }).catch(err => console.error('Save failed', err));
+}
+
+document.addEventListener('click', e => {
+  if (e.target.classList.contains('lightbox-image')) {
+    showLightbox(Array.from(document.querySelectorAll('.lightbox-image')), e.target);
+  }
+});
+
+function showLightbox(images, activeImage) {
+  let currentIndex = images.indexOf(activeImage);
+  const overlay = document.createElement('div');
+  overlay.className = 'lightbox-overlay';
+  overlay.innerHTML = `
+    <span class="close">&times;</span>
+    <span class="nav prev">&#10094;</span>
+    <img src="${activeImage.src}" />
+    <span class="nav next">&#10095;</span>
+  `;
+  document.body.appendChild(overlay);
+  const overlayImg = overlay.querySelector('img');
+  function update(idx) {
+    overlayImg.src = images[idx].src;
+    currentIndex = idx;
+  }
+  overlay.querySelector('.prev').onclick = () => update((currentIndex - 1 + images.length) % images.length);
+  overlay.querySelector('.next').onclick = () => update((currentIndex + 1) % images.length);
+  overlay.querySelector('.close').onclick = () => overlay.remove();
+  overlay.onclick = e => { if (e.target === overlay) overlay.remove(); };
+  document.onkeydown = e => {
+    if (e.key === 'Escape') overlay.remove();
+    if (e.key === 'ArrowLeft') overlay.querySelector('.prev').click();
+    if (e.key === 'ArrowRight') overlay.querySelector('.next').click();
+  };
+}

--- a/project-template.html
+++ b/project-template.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Infrastructural Public Cisterns</title>
+  <meta charset="UTF-8" />
+  <title>{{PROJECT_KEY}}</title>
   <link rel="stylesheet" href="../../H&dM.css" />
 </head>
 <body>
@@ -10,19 +10,15 @@
   <script>
     fetch('../../header.html')
       .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+      .then(data => { document.getElementById('site-header').innerHTML = data; });
   </script>
-
-  <main class="project-detail" data-project="infrastructural_public_cisterns">
-    <h2>Infrastructural Public Cisterns</h2>
+  <main class="project-detail" data-project="{{PROJECT_KEY}}">
+    <h2>{{PROJECT_KEY}}</h2>
     <div id="dynamic-project-sections"></div>
     <div id="admin-tools" style="display:none;">
       <input type="file" id="image-upload" multiple />
     </div>
   </main>
-
   <script src="../../project-editor.js"></script>
 </body>
 </html>

--- a/upload.php
+++ b/upload.php
@@ -1,0 +1,27 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $project = preg_replace('/[^a-zA-Z0-9_-]/', '', $_POST['project'] ?? '');
+    if (!$project) {
+        http_response_code(400);
+        echo json_encode(['error' => 'no project']);
+        exit;
+    }
+    $targetDir = "Projects/$project/Images/";
+    if (!is_dir($targetDir)) {
+        mkdir($targetDir, 0777, true);
+    }
+    $uploaded = [];
+    if (!empty($_FILES['images'])) {
+        foreach ($_FILES['images']['name'] as $i => $name) {
+            $tmp = $_FILES['images']['tmp_name'][$i];
+            $basename = basename($name);
+            move_uploaded_file($tmp, $targetDir . $basename);
+            $uploaded[] = ['filename' => $basename, 'title' => '', 'description' => '', 'layout' => ''];
+        }
+    }
+    echo json_encode($uploaded);
+} else {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+}
+?>


### PR DESCRIPTION
## Summary
- Add admin-only button to create new projects and backend script to scaffold directories
- Provide project editor for reordering, editing text, layout selection, and image uploads
- Include upload endpoint and styling for left/right/grid/carousel layouts

## Testing
- `php -l upload.php`
- `php -l create-project.php`
- `node --check project-editor.js`

------
https://chatgpt.com/codex/tasks/task_e_688fd6a93430832eadc164942d1d6a25