### PR TITLE
Display placeholder card for new projects without images

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -126,6 +126,20 @@ body.editing .project-card {
   z-index: 1;
 }
 
+.project-card .no-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0f0f0;
+  color: #666;
+  z-index: 1;
+}
+
 .project-card .project-title {
   position: relative;
   z-index: 2;

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -61,15 +61,20 @@
     function renderProjects() {
       container.innerHTML = '';
       projectEntries.forEach(([projectKey, images]) => {
-        if (images.length === 0) return;
-        const thumbnail = `${projectKey}/Images/${images[0].filename}`;
         const card = document.createElement('a');
         card.href = `${projectKey}/${projectKey}.html`;
         card.className = 'project-card';
-        card.innerHTML = `
-          <img src="${thumbnail}" alt="${images[0].title}">
-          <div class="project-title">${projectKey.replace(/_/g, ' ')}</div>
-        `;
+
+        let content = '';
+        if (images.length > 0) {
+          const thumbnail = `${projectKey}/Images/${images[0].filename}`;
+          content += `<img src="${thumbnail}" alt="${images[0].title}">`;
+        } else {
+          content += `<div class="no-image">No Image</div>`;
+        }
+        content += `<div class="project-title">${projectKey.replace(/_/g, ' ')}</div>`;
+        card.innerHTML = content;
+
         if (document.body.classList.contains('editing')) {
           card.setAttribute('draggable', true);
         }


### PR DESCRIPTION
## Summary
- Render project cards even when no images exist so admins can open new projects
- Add CSS styling for missing-image placeholder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fe0d53134832eb312dcecaef0a5e2