### PR TITLE
feat: streamline project layout editing

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -259,6 +259,25 @@ body.editing .project-card {
   font-size: 1rem;
 }
 
+/* Layout Toolbar */
+.layout-toolbar {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.layout-toolbar button {
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  border: 1px solid black;
+  background: white;
+}
+.layout-toolbar button.active {
+  background: black;
+  color: white;
+}
+
 /* PDFs (non-iframe display optional) */
 .pdf-link {
   display: flex;
@@ -316,4 +335,23 @@ body.editing .project-card {
   font-size: 2rem;
   color: white;
   cursor: pointer;
+}
+
+/* New Project Modal */
+#new-project-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+#new-project-modal .modal-content {
+  background: white;
+  padding: 20px;
+  border: 1px solid black;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Projects</title>
-  <link rel="stylesheet" href="../H&dM.css" />
+  <link rel="stylesheet" href="../H&amp;dM.css" />
 </head>
 <body>
   <!-- Header will be injected here -->
@@ -39,8 +39,36 @@
       addBtn.id = 'add-project-btn';
       addBtn.textContent = '+';
       addBtn.title = 'Add Project';
+      document.body.appendChild(addBtn);
+
+      const modal = document.createElement('div');
+      modal.id = 'new-project-modal';
+      modal.innerHTML = `
+        <div class="modal-content">
+          <label>Project identifier <input id="new-project-key" type="text"></label>
+          <div>
+            <button id="new-project-create">Create</button>
+            <button id="new-project-cancel">Cancel</button>
+          </div>
+        </div>`;
+      document.body.appendChild(modal);
+
+      const keyInput = modal.querySelector('#new-project-key');
+      const createBtn = modal.querySelector('#new-project-create');
+      const cancelBtn = modal.querySelector('#new-project-cancel');
+
       addBtn.addEventListener('click', () => {
-        const key = prompt('Enter new project identifier (use underscores instead of spaces)');
+        modal.style.display = 'flex';
+        keyInput.value = '';
+        keyInput.focus();
+      });
+
+      cancelBtn.addEventListener('click', () => {
+        modal.style.display = 'none';
+      });
+
+      createBtn.addEventListener('click', () => {
+        const key = keyInput.value.trim();
         if (!key) return;
         if (projectEntries.some(([k]) => k === key)) {
           alert('Project already exists');
@@ -54,8 +82,8 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ key })
         }).catch(err => console.error('create-project failed', err));
+        modal.style.display = 'none';
       });
-      document.body.appendChild(addBtn);
     }
 
     function renderProjects() {

--- a/create-project.php
+++ b/create-project.php
@@ -7,12 +7,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         echo json_encode(['error' => 'invalid key']);
         exit;
     }
+
     $dir = "Projects/$key";
     if (!is_dir($dir)) {
-        mkdir("$dir/Images", 0777, true);
-        $template = file_get_contents('project-template.html');
+        if (!mkdir("$dir/Images", 0777, true)) {
+            http_response_code(500);
+            echo json_encode(['error' => 'failed to create project directory']);
+            exit;
+        }
+        $template = @file_get_contents('project-template.html');
+        if ($template === false) {
+            http_response_code(500);
+            echo json_encode(['error' => 'missing project template']);
+            exit;
+        }
         $html = str_replace('{{PROJECT_KEY}}', $key, $template);
-        file_put_contents("$dir/$key.html", $html);
+        if (file_put_contents("$dir/$key.html", $html) === false) {
+            http_response_code(500);
+            echo json_encode(['error' => 'failed to write project file']);
+            exit;
+        }
+    }
+
+    $projectsFile = 'all-projects.json';
+    $projects = file_exists($projectsFile)
+        ? json_decode(file_get_contents($projectsFile), true)
+        : [];
+    if (!isset($projects[$key])) {
+        $projects[$key] = [];
+        file_put_contents($projectsFile, json_encode($projects, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
     echo json_encode(['status' => 'ok']);
 } else {

--- a/project-editor.js
+++ b/project-editor.js
@@ -27,22 +27,24 @@ function render() {
       <div class="project-text">
         <h3 contenteditable="${isAdmin}">${img.title}</h3>
         <p contenteditable="${isAdmin}">${img.description}</p>
-        ${isAdmin ? `<select class="layout-select">
-            <option value="">Default</option>
-            <option value="left">Left</option>
-            <option value="right">Right</option>
-            <option value="grid-2">Grid 2</option>
-            <option value="grid-3">Grid 3</option>
-            <option value="carousel">Carousel</option>
-          </select>` : ''}
+        ${isAdmin ? `<div class="layout-toolbar">
+            <button data-layout="">Default</button>
+            <button data-layout="left">Left</button>
+            <button data-layout="right">Right</button>
+            <button data-layout="grid-2">Grid 2</button>
+            <button data-layout="grid-3">Grid 3</button>
+            <button data-layout="carousel">Carousel</button>
+          </div>` : ''}
       </div>
     `;
     if (isAdmin) {
-      const sel = section.querySelector('.layout-select');
-      sel.value = img.layout || '';
-      sel.addEventListener('change', e => {
-        images[index].layout = e.target.value;
-        save();
+      section.querySelectorAll('.layout-toolbar button').forEach(btn => {
+        if (btn.dataset.layout === (img.layout || '')) btn.classList.add('active');
+        btn.addEventListener('click', () => {
+          images[index].layout = btn.dataset.layout;
+          render();
+          save();
+        });
       });
       section.querySelector('h3').addEventListener('input', e => {
         images[index].title = e.target.innerText;


### PR DESCRIPTION
## Summary
- improve project scaffolding with error checks
- replace layout dropdown with inline toolbar
- add modal workflow for creating projects

## Testing
- `php -l create-project.php`
- `node --check project-editor.js`
- `tidy -qe Projects/Projects.html`


------
https://chatgpt.com/codex/tasks/task_e_688fe336de18832e8a76279c15c9d200