### PR TITLE
feat: choose project cover image

### DIFF
--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -65,13 +65,14 @@
         card.href = `${projectKey}/${projectKey}.html`;
         card.className = 'project-card';
 
-        let content = '';
-        if (images.length > 0) {
-          const thumbnail = `${projectKey}/Images/${images[0].filename}`;
-          content += `<img src="${thumbnail}" alt="${images[0].title}">`;
-        } else {
-          content += `<div class="no-image">No Image</div>`;
-        }
+      let content = '';
+      if (images.length > 0) {
+        const cover = images.find(img => img.cover) || images[0];
+        const thumbnail = `${projectKey}/Images/${cover.filename}`;
+        content += `<img src="${thumbnail}" alt="${cover.title}">`;
+      } else {
+        content += `<div class="no-image">No Image</div>`;
+      }
         content += `<div class="project-title">${projectKey.replace(/_/g, ' ')}</div>`;
         card.innerHTML = content;
 

--- a/project-editor.js
+++ b/project-editor.js
@@ -27,6 +27,7 @@ function render() {
       <div class="project-text">
         <h3 contenteditable="${isAdmin}">${img.title}</h3>
         <p contenteditable="${isAdmin}">${img.description}</p>
+        ${isAdmin ? `<button class="cover-btn">${img.cover ? 'Cover Image' : 'Set as Cover'}</button>` : ''}
         ${isAdmin ? `<select class="layout-select">
             <option value="">Default</option>
             <option value="left">Left</option>
@@ -38,6 +39,13 @@ function render() {
       </div>
     `;
     if (isAdmin) {
+      const coverBtn = section.querySelector('.cover-btn');
+      coverBtn.addEventListener('click', () => {
+        images.forEach(i => i.cover = false);
+        images[index].cover = true;
+        render();
+        save();
+      });
       const sel = section.querySelector('.layout-select');
       sel.value = img.layout || '';
       sel.addEventListener('change', e => {


### PR DESCRIPTION
## Summary
- allow admins to mark an image as a project's card cover directly from the project editor
- render project cards using the selected cover image

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fe5b35080832eb75f70b07e88feed