### PR TITLE
Add account creation with email verification

### DIFF
--- a/header.html
+++ b/header.html
@@ -8,7 +8,7 @@
     <a href="/repository/slope-band-analysis.html">Slope Band Analysis</a>
     <a href="/repository/CNC-CutSheet-layout/CNC-CutSheet-layout.html">CNC CutSheet Layout</a>
     <a href="/repository/Contact/Contact.html">Contact</a>
-    <a href="/repository/admin.html">Login</a>
+    <a href="/repository/login/index.html">Login</a>
   </nav>
   <span id="edit-icon" class="edit-icon" title="Edit" style="display:none;">✏️</span>
 </header>

--- a/login/create-account.html
+++ b/login/create-account.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Create Account</title>
+  <link rel="stylesheet" href="../H&dM.css">
+  <style>
+    .login-container {
+      max-width: 400px;
+      margin: 100px auto;
+      padding: 30px;
+      border: 1px solid #000;
+      border-radius: 12px;
+      text-align: center;
+    }
+    input[type="text"], input[type="password"], input[type="email"] {
+      width: 100%;
+      padding: 10px;
+      margin: 10px 0;
+    }
+    button {
+      padding: 10px 20px;
+      border: 1px solid black;
+      background: white;
+      cursor: pointer;
+    }
+    button:hover {
+      background: black;
+      color: white;
+    }
+    #verification-section {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-container">
+    <h2>Create Account</h2>
+    <input type="text" id="new-username" placeholder="Username" />
+    <input type="email" id="new-email" placeholder="Email" />
+    <input type="password" id="new-password" placeholder="Password" />
+    <button onclick="sendCode()">Send Verification Code</button>
+    <div id="verification-section">
+      <input type="text" id="verification-code" placeholder="Verification Code" />
+      <button onclick="verifyCode()">Verify</button>
+      <p id="verification-message" style="color:red;"></p>
+    </div>
+    <p><a href="index.html">Back to Login</a></p>
+  </div>
+
+  <script>
+    let generatedCode = '';
+    function sendCode() {
+      const email = document.getElementById('new-email').value;
+      generatedCode = Math.floor(100000 + Math.random() * 900000).toString();
+      fetch('send_verification_email.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email, code: generatedCode })
+      }).then(() => {
+        document.getElementById('verification-section').style.display = 'block';
+      });
+    }
+    function verifyCode() {
+      const entered = document.getElementById('verification-code').value;
+      if (entered === generatedCode) {
+        const username = document.getElementById('new-username').value;
+        const password = document.getElementById('new-password').value;
+        const email = document.getElementById('new-email').value;
+        const users = JSON.parse(localStorage.getItem('users') || '[]');
+        users.push({ username, password, email, isAdmin: false });
+        localStorage.setItem('users', JSON.stringify(users));
+        window.location.href = 'index.html';
+      } else {
+        document.getElementById('verification-message').textContent = 'Invalid code';
+      }
+    }
+  </script>
+</body>
+</html>

--- a/login/index.html
+++ b/login/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <link rel="stylesheet" href="../H&dM.css">
+  <style>
+    .login-container {
+      max-width: 400px;
+      margin: 100px auto;
+      padding: 30px;
+      border: 1px solid #000;
+      border-radius: 12px;
+      text-align: center;
+    }
+    input[type="text"], input[type="password"] {
+      width: 100%;
+      padding: 10px;
+      margin: 10px 0;
+    }
+    button {
+      padding: 10px 20px;
+      border: 1px solid black;
+      background: white;
+      cursor: pointer;
+    }
+    button:hover {
+      background: black;
+      color: white;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-container">
+    <h2>Login</h2>
+    <input type="text" id="username" placeholder="Username" />
+    <input type="password" id="password" placeholder="Password" />
+    <button onclick="login()">Login</button>
+    <p id="error-message" style="color:red;"></p>
+    <p><a href="create-account.html">Create Account</a></p>
+  </div>
+
+  <script>
+    function login() {
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const users = JSON.parse(localStorage.getItem('users') || '[]');
+      const user = users.find(u => u.username === username && u.password === password);
+      if (user) {
+        if (user.isAdmin) {
+          localStorage.setItem('isAdmin', 'true');
+          window.location.href = '../Projects/Projects.html';
+        } else {
+          localStorage.removeItem('isAdmin');
+          window.location.href = '../index.html';
+        }
+      } else {
+        document.getElementById('error-message').textContent = 'Invalid credentials';
+      }
+    }
+  </script>
+</body>
+</html>

--- a/login/send_verification_email.php
+++ b/login/send_verification_email.php
@@ -1,0 +1,15 @@
+<?php
+header('Content-Type: application/json');
+$input = json_decode(file_get_contents('php://input'), true);
+$email = $input['email'] ?? '';
+$code = $input['code'] ?? '';
+if ($email && $code) {
+    $subject = 'Account Verification';
+    $message = 'Your verification code is: ' . $code;
+    $headers = 'From: no-reply@example.com' . "\r\n" .
+               'Reply-To: no-reply@example.com' . "\r\n" .
+               'X-Mailer: PHP/' . phpversion();
+    @mail($email, $subject, $message, $headers);
+}
+echo json_encode(['status' => 'ok']);
+?>


### PR DESCRIPTION
## Summary
- Add login page that authenticates stored users and grants admin access when appropriate
- Provide account creation page with email verification workflow
- Hook up PHP script to send verification codes and update site header link

## Testing
- `php -l login/send_verification_email.php`

------
https://chatgpt.com/codex/tasks/task_e_688fe6c1805c832e959edd22ecbcd88d