### PR TITLE
Send verification email with server-generated code

### DIFF
--- a/login/create-account.html
+++ b/login/create-account.html
@@ -52,12 +52,14 @@
     let generatedCode = '';
     function sendCode() {
       const email = document.getElementById('new-email').value;
-      generatedCode = Math.floor(100000 + Math.random() * 900000).toString();
       fetch('send_verification_email.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email, code: generatedCode })
-      }).then(() => {
+        body: JSON.stringify({ email: email })
+      })
+      .then(response => response.json())
+      .then(data => {
+        generatedCode = data.code;
         document.getElementById('verification-section').style.display = 'block';
       });
     }

--- a/login/send_verification_email.php
+++ b/login/send_verification_email.php
@@ -2,14 +2,16 @@
 header('Content-Type: application/json');
 $input = json_decode(file_get_contents('php://input'), true);
 $email = $input['email'] ?? '';
-$code = $input['code'] ?? '';
-if ($email && $code) {
+$code = random_int(100000, 999999);
+if ($email) {
     $subject = 'Account Verification';
     $message = 'Your verification code is: ' . $code;
     $headers = 'From: no-reply@example.com' . "\r\n" .
                'Reply-To: no-reply@example.com' . "\r\n" .
                'X-Mailer: PHP/' . phpversion();
     @mail($email, $subject, $message, $headers);
+    echo json_encode(['status' => 'ok', 'code' => strval($code)]);
+} else {
+    echo json_encode(['status' => 'error', 'message' => 'Email required']);
 }
-echo json_encode(['status' => 'ok']);
 ?>


### PR DESCRIPTION
## Summary
- Generate random six-digit verification code on the server and email it back to the user.
- Update account creation page to fetch the server-generated code and display verification inputs.

## Testing
- `php -l login/send_verification_email.php`


------
https://chatgpt.com/codex/tasks/task_e_688fe964055c832eb44780ba6505f360