### PR TITLE
Add logout feature

### DIFF
--- a/CNC-CutSheet-layout/CNC-CutSheet-layout.html
+++ b/CNC-CutSheet-layout/CNC-CutSheet-layout.html
@@ -10,12 +10,9 @@
   <main>
     <p>This feature is still in construction. COME BACK SOON!</p>
   </main>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('../header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('../header.html');
   </script>
 </body>
 </html>

--- a/Contact/Contact.html
+++ b/Contact/Contact.html
@@ -11,12 +11,9 @@
     <p>Nabil Davidson<br>IG: ParametricPlanning</p>
     <p>EmaLee Davdison<br>IG: EmaLeeDavdison.arch</p>
   </main>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('../header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('../header.html');
   </script>
 </body>
 </html>

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -12,24 +12,22 @@
     <div class="projects-grid" id="projects-container"></div>
   </main>
 
+  <script src="/repository/header.js"></script>
   <script>
     const isAdmin = localStorage.getItem('isAdmin') === 'true';
 
-    fetch('../header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-        if (isAdmin) {
-          const icon = document.getElementById('edit-icon');
-          if (icon) {
-            icon.style.display = 'block';
-            icon.addEventListener('click', () => {
-              document.body.classList.toggle('editing');
-              renderProjects();
-            });
-          }
+    loadHeader('../header.html', () => {
+      if (isAdmin) {
+        const icon = document.getElementById('edit-icon');
+        if (icon) {
+          icon.style.display = 'block';
+          icon.addEventListener('click', () => {
+            document.body.classList.toggle('editing');
+            renderProjects();
+          });
         }
-      });
+      }
+    });
 
     let projectEntries = [];
     const container = document.getElementById('projects-container');

--- a/Projects/comprehensive_studio/comprehensive_studio.html
+++ b/Projects/comprehensive_studio/comprehensive_studio.html
@@ -7,12 +7,9 @@
 </head>
 <body>
   <div id="site-header"></div>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('../../header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('../../header.html');
   </script>
 
   <main class="project-detail" data-project="comprehensive_studio">

--- a/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
+++ b/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
@@ -7,12 +7,9 @@
 </head>
 <body>
   <div id="site-header"></div>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('../../header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('../../header.html');
   </script>
 
   <main class="project-detail" data-project="infrastructural_public_cisterns">

--- a/dashboard.html
+++ b/dashboard.html
@@ -57,12 +57,9 @@
 </head>
 <body>
   <div id="site-header"></div>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('header.html');
   </script>
 
   <h2>Project Dashboard</h2>

--- a/header.html
+++ b/header.html
@@ -8,7 +8,8 @@
     <a href="/repository/slope-band-analysis.html">Slope Band Analysis</a>
     <a href="/repository/CNC-CutSheet-layout/CNC-CutSheet-layout.html">CNC CutSheet Layout</a>
     <a href="/repository/Contact/Contact.html">Contact</a>
-    <a href="/repository/login/index.html">Login</a>
+    <a href="/repository/login/index.html" id="login-link">Login</a>
+    <a href="#" id="logout-link" style="display:none;">Logout</a>
   </nav>
   <span id="edit-icon" class="edit-icon" title="Edit" style="display:none;">✏️</span>
 </header>

--- a/header.js
+++ b/header.js
@@ -1,0 +1,24 @@
+function loadHeader(path, callback) {
+  fetch(path)
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('site-header').innerHTML = html;
+      const isAdmin = localStorage.getItem('isAdmin') === 'true';
+      const loginLink = document.getElementById('login-link');
+      const logoutLink = document.getElementById('logout-link');
+      if (isAdmin) {
+        if (loginLink) loginLink.style.display = 'none';
+        if (logoutLink) {
+          logoutLink.style.display = 'inline';
+          logoutLink.addEventListener('click', () => {
+            localStorage.removeItem('isAdmin');
+            window.location.href = '/repository/index.html';
+          });
+        }
+      } else {
+        if (loginLink) loginLink.style.display = 'inline';
+        if (logoutLink) logoutLink.style.display = 'none';
+      }
+      if (callback) callback(isAdmin);
+    });
+}

--- a/index.html
+++ b/index.html
@@ -16,12 +16,9 @@
   </main>
 
   <!-- Load navigation from header.html -->
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('header.html');
   </script>
 
 </body>

--- a/ownership-map/ownership-map.html
+++ b/ownership-map/ownership-map.html
@@ -10,12 +10,9 @@
   <main>
     <p>This feature is a work in progress. COME BACK SOON!</p>
   </main>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('../header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('../header.html');
   </script>
 </body>
 </html>

--- a/project-template.html
+++ b/project-template.html
@@ -7,10 +7,9 @@
 </head>
 <body>
   <div id="site-header"></div>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('../../header.html')
-      .then(res => res.text())
-      .then(data => { document.getElementById('site-header').innerHTML = data; });
+    loadHeader('../../header.html');
   </script>
   <main class="project-detail" data-project="{{PROJECT_KEY}}">
     <h2>{{PROJECT_KEY}}</h2>

--- a/slope-band-analysis.html
+++ b/slope-band-analysis.html
@@ -10,12 +10,9 @@
   <main>
     <p>Contact Nabil Davidson for this script. It will be on the web sometime shortly. COME BACK SOON!</p>
   </main>
+  <script src="/repository/header.js"></script>
   <script>
-    fetch('header.html')
-      .then(res => res.text())
-      .then(data => {
-        document.getElementById('site-header').innerHTML = data;
-      });
+    loadHeader('header.html');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add logout link to site header and handle login/logout state in a new shared script
- update pages to load the header via `loadHeader` so logout is available across the site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689002ad6e58832eb569feb09a24dc65