### PR TITLE
Load project data from all-projects.json

### DIFF
--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -111,7 +111,7 @@
       });
     }
 
-      fetch('../list-projects.php')
+      fetch('../all-projects.json')
       .then(response => response.json())
       .then(data => {
         projectEntries = Object.entries(data).map(([key, value]) => {
@@ -123,7 +123,7 @@
         renderProjects();
       })
       .catch(error => {
-        console.error('Error loading list-projects.php:', error);
+        console.error('Error loading all-projects.json:', error);
       });
 
     document.addEventListener('dragstart', e => {

--- a/project-editor.js
+++ b/project-editor.js
@@ -6,7 +6,7 @@ let allProjects = {};
 let images = [];
 let dragIndex = null;
 
-fetch('../../list-projects.php')
+fetch('../../all-projects.json')
   .then(res => res.json())
   .then(data => {
     allProjects = data;


### PR DESCRIPTION
## Summary
- Load project editor data from the static `all-projects.json` file instead of PHP endpoint.
- Update projects listing page to pull from `all-projects.json` and adjust error handling.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689021487150832e9385fb97ad372b4a