### PR TITLE
Improve image load performance with responsive sizing

### DIFF
--- a/header.js
+++ b/header.js
@@ -19,6 +19,12 @@ function loadHeader(path, callback) {
         if (loginLink) loginLink.style.display = 'inline';
         if (logoutLink) logoutLink.style.display = 'none';
       }
+      if (!document.getElementById('responsive-images-script')) {
+        const script = document.createElement('script');
+        script.src = '/repository/responsive-images.js';
+        script.id = 'responsive-images-script';
+        document.head.appendChild(script);
+      }
       if (callback) callback(isAdmin);
     });
 }

--- a/project-editor.js
+++ b/project-editor.js
@@ -80,6 +80,7 @@ function render() {
       section.addEventListener('drop', drop);
     }
     container.appendChild(section);
+    if (window.applyResponsiveImages) applyResponsiveImages(section);
   });
 }
 

--- a/resize.php
+++ b/resize.php
@@ -1,0 +1,59 @@
+<?php
+$src = $_GET['src'] ?? '';
+$w = intval($_GET['w'] ?? 0);
+if (!$src || $w <= 0) {
+    http_response_code(400);
+    exit('bad request');
+}
+$src = ltrim($src, '/');
+if (!preg_match('/^[A-Za-z0-9_\-\.\/]+$/', $src)) {
+    http_response_code(400);
+    exit('invalid path');
+}
+$path = __DIR__ . '/' . $src;
+if (!file_exists($path)) {
+    http_response_code(404);
+    exit('not found');
+}
+$info = getimagesize($path);
+if (!$info) {
+    http_response_code(415);
+    exit('not image');
+}
+list($origW, $origH) = $info;
+$mime = $info['mime'];
+$h = (int)($origH * ($w / $origW));
+switch ($mime) {
+    case 'image/jpeg':
+    case 'image/jpg':
+        $srcImg = imagecreatefromjpeg($path);
+        break;
+    case 'image/png':
+        $srcImg = imagecreatefrompng($path);
+        break;
+    case 'image/gif':
+        $srcImg = imagecreatefromgif($path);
+        break;
+    default:
+        http_response_code(415);
+        exit('unsupported');
+}
+$dst = imagecreatetruecolor($w, $h);
+if ($mime === 'image/png') {
+    imagealphablending($dst, false);
+    imagesavealpha($dst, true);
+}
+imagecopyresampled($dst, $srcImg, 0, 0, 0, 0, $w, $h, $origW, $origH);
+header('Content-Type: ' . $mime);
+switch ($mime) {
+    case 'image/png':
+        imagepng($dst);
+        break;
+    case 'image/gif':
+        imagegif($dst);
+        break;
+    default:
+        imagejpeg($dst, null, 85);
+}
+imagedestroy($srcImg);
+imagedestroy($dst);

--- a/responsive-images.js
+++ b/responsive-images.js
@@ -1,0 +1,31 @@
+function applyResponsiveImages(root = document) {
+  const imgs = root.querySelectorAll('img');
+  imgs.forEach(img => {
+    if (img.dataset.originalSrc === undefined) {
+      const orig = img.getAttribute('src');
+      if (!orig) return;
+      img.dataset.originalSrc = orig;
+    }
+    const origSrc = img.dataset.originalSrc;
+    let displayWidth = img.clientWidth;
+    if (!displayWidth) {
+      displayWidth = img.parentElement ? img.parentElement.clientWidth : window.innerWidth;
+    }
+    const targetWidth = Math.ceil(displayWidth * window.devicePixelRatio);
+    const absUrl = new URL(origSrc, window.location.href);
+    let path = absUrl.pathname;
+    if (path.startsWith('/')) path = path.substring(1);
+    path = path.replace(/^repository\//, '');
+    img.src = `/repository/resize.php?src=${encodeURIComponent(path)}&w=${targetWidth}`;
+    img.loading = 'lazy';
+  });
+}
+function initResponsiveImages() {
+  applyResponsiveImages();
+  window.addEventListener('resize', () => applyResponsiveImages());
+}
+if (document.readyState === 'complete') {
+  initResponsiveImages();
+} else {
+  window.addEventListener('load', initResponsiveImages);
+}


### PR DESCRIPTION
## Summary
- Inject responsive image script via `header.js` to size images for the device
- Add `responsive-images.js` and `resize.php` to request appropriately scaled images
- Re-render project images with responsive loader in `project-editor.js`

## Testing
- `php -l resize.php`
- `node --check responsive-images.js`
- `node --check header.js`
- `node --check project-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_689034346bac832e80e1477e8786860e