### PR TITLE
Load navigation and images earlier for snappier pages

### DIFF
--- a/CNC-CutSheet-layout/CNC-CutSheet-layout.html
+++ b/CNC-CutSheet-layout/CNC-CutSheet-layout.html
@@ -4,15 +4,12 @@
   <meta charset="UTF-8" />
   <title>CNC CutSheet Layout</title>
   <link rel="stylesheet" href="../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
   <main>
     <p>This feature is still in construction. COME BACK SOON!</p>
   </main>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../header.html');
-  </script>
 </body>
 </html>

--- a/Contact/Contact.html
+++ b/Contact/Contact.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Contact</title>
   <link rel="stylesheet" href="../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -11,9 +12,5 @@
     <p>Nabil Davidson<br>IG: ParametricPlanning</p>
     <p>EmaLee Davdison<br>IG: EmaLeeDavdison.arch</p>
   </main>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../header.html');
-  </script>
 </body>
 </html>

--- a/Projects/3247/3247.html
+++ b/Projects/3247/3247.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <title>32.47°</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>32.47°</h2>

--- a/Projects/Casework in Munich/Casework in Munich.html
+++ b/Projects/Casework in Munich/Casework in Munich.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <title>Casework in Munich</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>Casework in Munich</h2>

--- a/Projects/DU OCTA PLEX/DU OCTA PLEX.html
+++ b/Projects/DU OCTA PLEX/DU OCTA PLEX.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <title>DU OCTA PLEX</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>DU OCTA PLEX</h2>

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Projects</title>
   <link rel="stylesheet" href="../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
@@ -43,9 +44,5 @@
       </a>
     </div>
   </main>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../header.html');
-  </script>
 </body>
 </html>

--- a/Projects/comprehensive_studio/comprehensive_studio.html
+++ b/Projects/comprehensive_studio/comprehensive_studio.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8" />
   <title>Comprehensive Studio</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>Comprehensive Studio</h2>

--- a/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
+++ b/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <title>Infrastructural Public Cisterns</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>Infrastructural Public Cisterns</h2>

--- a/Projects/non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html
+++ b/Projects/non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <title>Non-Planar Printed Ceramic Studio</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>Non-Planar Printed Ceramic Studio</h2>

--- a/Projects/six_houses_two_walls/six_houses_two_walls.html
+++ b/Projects/six_houses_two_walls/six_houses_two_walls.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <title>Six Houses Two Walls</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>Six Houses Two Walls</h2>

--- a/Projects/space_arboretum/space_arboretum.html
+++ b/Projects/space_arboretum/space_arboretum.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <title>Space Arboretum</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
 
     <main class="project-detail">
     <h2>Space Arboretum</h2>

--- a/dashboard.html
+++ b/dashboard.html
@@ -54,13 +54,10 @@
       margin-top: 8px;
     }
   </style>
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('header.html');
-  </script>
 
   <h2>Project Dashboard</h2>
   <div class="carousel" id="project-carousel">

--- a/header.js
+++ b/header.js
@@ -1,5 +1,5 @@
-function loadHeader(path, callback) {
-  fetch(path)
+function loadHeader(callback) {
+  fetch('/repository/header.html')
     .then(res => res.text())
     .then(html => {
       document.getElementById('site-header').innerHTML = html;
@@ -19,12 +19,19 @@ function loadHeader(path, callback) {
         if (loginLink) loginLink.style.display = 'inline';
         if (logoutLink) logoutLink.style.display = 'none';
       }
-      if (!document.getElementById('responsive-images-script')) {
-        const script = document.createElement('script');
-        script.src = '/repository/responsive-images.js';
-        script.id = 'responsive-images-script';
-        document.head.appendChild(script);
-      }
       if (callback) callback(isAdmin);
     });
 }
+
+if (!document.getElementById('responsive-images-script')) {
+  const script = document.createElement('script');
+  script.src = '/repository/responsive-images.js';
+  script.defer = true;
+  script.id = 'responsive-images-script';
+  document.head.appendChild(script);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadHeader();
+});
+

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Your Page Title</title>
   <link rel="stylesheet" href="H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
 
@@ -13,13 +14,6 @@
   <!-- Main Content -->
   <main>
     <p>Welcome to your site. More coming soon.</p>
-  </main>
-
-  <!-- Load navigation from header.html -->
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('header.html');
-  </script>
-
+  </main>
 </body>
 </html>

--- a/ownership-map/ownership-map.html
+++ b/ownership-map/ownership-map.html
@@ -4,15 +4,12 @@
   <meta charset="UTF-8" />
   <title>Ownership Map</title>
   <link rel="stylesheet" href="../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
   <main>
     <p>This feature is a work in progress. COME BACK SOON!</p>
   </main>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../header.html');
-  </script>
 </body>
 </html>

--- a/project-template.html
+++ b/project-template.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8" />
   <title>{{PROJECT_KEY}}</title>
   <link rel="stylesheet" href="../../H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('../../header.html');
-  </script>
   <main class="project-detail" data-project="{{PROJECT_KEY}}">
     <h2>{{PROJECT_KEY}}</h2>
     <div id="dynamic-project-sections"></div>

--- a/responsive-images.js
+++ b/responsive-images.js
@@ -18,14 +18,15 @@ function applyResponsiveImages(root = document) {
     path = path.replace(/^repository\//, '');
     img.src = `/repository/resize.php?src=${encodeURIComponent(path)}&w=${targetWidth}`;
     img.loading = 'lazy';
+    img.decoding = 'async';
   });
 }
 function initResponsiveImages() {
   applyResponsiveImages();
   window.addEventListener('resize', () => applyResponsiveImages());
 }
-if (document.readyState === 'complete') {
+if (document.readyState !== 'loading') {
   initResponsiveImages();
 } else {
-  window.addEventListener('load', initResponsiveImages);
+  document.addEventListener('DOMContentLoaded', initResponsiveImages);
 }

--- a/slope-band-analysis.html
+++ b/slope-band-analysis.html
@@ -4,15 +4,12 @@
   <meta charset="UTF-8" />
   <title>Slope Band Analysis</title>
   <link rel="stylesheet" href="H&dM.css" />
+  <script src="/repository/header.js" defer></script>
 </head>
 <body>
   <div id="site-header"></div>
   <main>
     <p>Contact Nabil Davidson for this script. It will be on the web sometime shortly. COME BACK SOON!</p>
   </main>
-  <script src="/repository/header.js"></script>
-  <script>
-    loadHeader('header.html');
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Auto-load site header and responsive-image handler on DOMContentLoaded
- Replace late image resizing with early lazy + async decoding
- Include deferred header script in page `<head>` for lighter, consistent navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890448aa684832eb9a51c9164bb3996