### PR TITLE
Improve mobile project layout

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -358,3 +358,35 @@ body.editing .project-card {
   flex-direction: column;
   gap: 10px;
 }
+
+@media (max-width: 600px) {
+  .projects-grid {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+
+  .project-card {
+    max-width: none;
+    width: 100%;
+  }
+
+  .project-card .project-title {
+    display: none;
+  }
+
+  .project-section {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 20px;
+  }
+
+  .project-section img {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .project-text {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Improve mobile layout for project listing and detail views
- Hide project titles and descriptions on small screens for larger images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890455b45c8832eaf2293f6391735bc