### PR TITLE
Remove text placeholder and center project images

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -10,8 +10,9 @@ body {
   background-color: #ffffff;
   color: #000000;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  margin: 10px;
+  border: 1px solid #000;
   padding: 20px;
-  margin-top: 40px;
 }
 
 /* Header */
@@ -248,18 +249,16 @@ body.editing .project-card {
   gap: 20px;
 }
 .project-section img {
-  max-width: 50%;
+  max-width: 100%;
+  width: 100%;
   max-height: 900px;   /* Limit tall images */
   height: auto;
-  width: auto;
   object-fit: contain; /* Prevents cropping */
 }
 
+/* Hide placeholder text blocks so images can center */
 .project-text {
-  max-width: 500px;
-  flex: 1;
-  padding-top: 10px;
-  font-size: 1rem;
+  display: none;
 }
 
 /* Layout Toolbar */


### PR DESCRIPTION
## Summary
- Remove unused text blocks so project images center correctly
- Expand project images to full width and add page border for a consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890533f0e90832e9ec5311ef68de728