### PR TITLE
feat: improve responsive image handling

### DIFF
--- a/responsive-images.js
+++ b/responsive-images.js
@@ -6,25 +6,32 @@ function applyResponsiveImages(root = document) {
       if (!orig) return;
       img.dataset.originalSrc = orig;
     }
+
     const origSrc = img.dataset.originalSrc;
-    let displayWidth = img.clientWidth;
-    if (!displayWidth) {
-      displayWidth = img.parentElement ? img.parentElement.clientWidth : window.innerWidth;
-    }
-    const targetWidth = Math.ceil(displayWidth * window.devicePixelRatio);
     const absUrl = new URL(origSrc, window.location.href);
     let path = absUrl.pathname;
     if (path.startsWith('/')) path = path.substring(1);
     path = path.replace(/^repository\//, '');
-    img.src = `/repository/resize.php?src=${encodeURIComponent(path)}&w=${targetWidth}`;
+
+    const widths = [320, 640, 960, 1280, 1920];
+    const srcset = widths
+      .map(w => `/repository/resize.php?src=${encodeURIComponent(path)}&w=${w} ${w}w`)
+      .join(', ');
+
+    const displayWidth = img.clientWidth || (img.parentElement ? img.parentElement.clientWidth : window.innerWidth);
+
+    img.srcset = srcset;
+    img.sizes = `${displayWidth}px`;
+    img.src = `/repository/resize.php?src=${encodeURIComponent(path)}&w=640`;
     img.loading = 'lazy';
     img.decoding = 'async';
   });
 }
+
 function initResponsiveImages() {
   applyResponsiveImages();
-  window.addEventListener('resize', () => applyResponsiveImages());
 }
+
 if (document.readyState !== 'loading') {
   initResponsiveImages();
 } else {


### PR DESCRIPTION
## Summary
- use srcset and sizes for responsive image loading
- drop resize listener to avoid repeated image swaps

## Testing
- `node --check responsive-images.js`


------
https://chatgpt.com/codex/tasks/task_e_689056afd098832e9dbf645f6289378f