### PR TITLE
feat: add lazy loading placeholder

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -388,3 +388,12 @@ body.editing .project-card {
     display: none;
   }
 }
+
+/* Lazy loading placeholder */
+.lazy-image {
+  filter: blur(20px);
+  transition: filter 0.3s ease;
+}
+.lazy-image.loaded {
+  filter: blur(0);
+}

--- a/responsive-images.js
+++ b/responsive-images.js
@@ -20,11 +20,22 @@ function applyResponsiveImages(root = document) {
 
     const displayWidth = img.clientWidth || (img.parentElement ? img.parentElement.clientWidth : window.innerWidth);
 
-    img.srcset = srcset;
-    img.sizes = `${displayWidth}px`;
-    img.src = `/repository/resize.php?src=${encodeURIComponent(path)}&w=640`;
+    const placeholder = `/repository/resize.php?src=${encodeURIComponent(path)}&w=20`;
+
+    img.classList.add('lazy-image');
+    const onLoad = () => {
+      if (!img.currentSrc.includes('w=20')) {
+        img.classList.add('loaded');
+        img.removeEventListener('load', onLoad);
+      }
+    };
+    img.addEventListener('load', onLoad);
+
     img.loading = 'lazy';
     img.decoding = 'async';
+    img.src = placeholder;
+    img.srcset = srcset;
+    img.sizes = `${displayWidth}px`;
   });
 }
 


### PR DESCRIPTION
## Summary
- blur up image placeholders and switch to full quality on load
- style placeholder transition

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/repository/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68906022771c832e84e7c617a42a4cef