### PR TITLE
feat: add fade-in animation for images

### DIFF
--- a/header.js
+++ b/header.js
@@ -31,7 +31,22 @@ if (!document.getElementById('responsive-images-script')) {
   document.head.appendChild(script);
 }
 
+function initImageFadeIn(root = document) {
+  const imgs = root.querySelectorAll('img');
+  imgs.forEach(img => {
+    img.style.opacity = '0';
+    img.style.transition = 'opacity 0.5s ease-in';
+    const show = () => { img.style.opacity = '1'; };
+    if (img.complete) {
+      requestAnimationFrame(show);
+    } else {
+      img.addEventListener('load', show, { once: true });
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  loadHeader();
+  loadHeader(() => initImageFadeIn(document.getElementById('site-header')));
+  initImageFadeIn();
 });
 


### PR DESCRIPTION
## Summary
- add fade-in animation for images as they load using onload events and opacity transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890603557e8832ea4809755bc4aa0e3