### PR TITLE
Optimize image handling with WebP thumbnails and lazy loading

### DIFF
--- a/Projects/3247/3247.html
+++ b/Projects/3247/3247.html
@@ -1,45 +1,44 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>32.47°</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>32.47°</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>32.47°</h2>
-
-    <div class="project-section">
-      <img src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Plan-01_Post Proccess-01.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>32.47°</h2>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Plan-01_Post Proccess-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Plan-01_Post Proccess-01.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/Casework in Munich/Casework in Munich.html
+++ b/Projects/Casework in Munich/Casework in Munich.html
@@ -1,31 +1,30 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Casework in Munich</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>Casework in Munich</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>Casework in Munich</h2>
-
-    <div class="project-section">
-      <img src="Images/IMG_7122_Post.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/IMG_7126_Post.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>Casework in Munich</h2>
+<div class="project-section">
+<img alt="" data-fullres="Images/IMG_7122_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7122_Post.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/IMG_7126_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7126_Post.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/DU OCTA PLEX/DU OCTA PLEX.html
+++ b/Projects/DU OCTA PLEX/DU OCTA PLEX.html
@@ -1,73 +1,72 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>DU OCTA PLEX</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>DU OCTA PLEX</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>DU OCTA PLEX</h2>
-
-    <div class="project-section">
-      <img src="Images/DSCF8996_Edited.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/DSCF9010_Edited.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/DSCF9021_Edited.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/DSCF9070_Edits.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/DSCF9087_Edited.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_056bae4b-05f4-4f98-9863-415a0695ff07.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/qr-code-71889601.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/qr-code-71889625.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>DU OCTA PLEX</h2>
+<div class="project-section">
+<img alt="" data-fullres="Images/DSCF8996_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF8996_Edited.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/DSCF9010_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9010_Edited.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/DSCF9021_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9021_Edited.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/DSCF9070_Edits.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9070_Edits.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/DSCF9087_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9087_Edited.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_056bae4b-05f4-4f98-9863-415a0695ff07.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_056bae4b-05f4-4f98-9863-415a0695ff07.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/qr-code-71889601.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/qr-code-71889601.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/qr-code-71889625.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/qr-code-71889625.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -1,48 +1,49 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <title>Projects</title>
-  <link rel="stylesheet" href="../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>Projects</title>
+<link href="../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-  <main>
-    <div class="projects-grid">
-      <a class="project-card" href="comprehensive_studio/comprehensive_studio.html">
-        <img src="comprehensive_studio/Images/250317_Rhino_Render_Final.jpg" alt="comprehensive studio">
-        <div class="project-title">comprehensive studio</div>
-      </a>
-      <a class="project-card" href="infrastructural_public_cisterns/infrastructural_public_cisterns.html">
-        <img src="infrastructural_public_cisterns/Images/IMG_8681.png" alt="infrastructural public cisterns">
-        <div class="project-title">infrastructural public cisterns</div>
-      </a>
-      <a class="project-card" href="Casework in Munich/Casework in Munich.html">
-        <img src="Casework in Munich/Images/IMG_7122_Post.png" alt="Casework in Munich">
-        <div class="project-title">Casework in Munich</div>
-      </a>
-      <a class="project-card" href="six_houses_two_walls/six_houses_two_walls.html">
-        <img src="six_houses_two_walls/Images/250503_Small Lots Big Impacts_Diagram-03.jpg" alt="six houses two walls">
-        <div class="project-title">six houses two walls</div>
-      </a>
-      <a class="project-card" href="non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html">
-        <img src="non-planar_printed_ceramic_studio/Images/Ceramic Studio Drawings-03.jpg" alt="non-planar printed ceramic studio">
-        <div class="project-title">non-planar printed ceramic studio</div>
-      </a>
-      <a class="project-card" href="3247/3247.html">
-        <img src="3247/Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" alt="3247">
-        <div class="project-title">3247</div>
-      </a>
-      <a class="project-card" href="DU OCTA PLEX/DU OCTA PLEX.html">
-        <img src="DU OCTA PLEX/Images/DSCF8996_Edited.png" alt="DU OCTA PLEX">
-        <div class="project-title">DU OCTA PLEX</div>
-      </a>
-      <a class="project-card" href="space_arboretum/space_arboretum.html">
-        <img src="space_arboretum/Images/Arboretum Final_Roof Plan_BW-01.jpg" alt="space arboretum">
-        <div class="project-title">space arboretum</div>
-      </a>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main>
+<div class="projects-grid">
+<a class="project-card" href="comprehensive_studio/comprehensive_studio.html">
+<img alt="comprehensive studio" data-fullres="comprehensive_studio/Images/250317_Rhino_Render_Final.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="comprehensive_studio/Images/thumbs/250317_Rhino_Render_Final.webp"/>
+<div class="project-title">comprehensive studio</div>
+</a>
+<a class="project-card" href="infrastructural_public_cisterns/infrastructural_public_cisterns.html">
+<img alt="infrastructural public cisterns" data-fullres="infrastructural_public_cisterns/Images/IMG_8681.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="infrastructural_public_cisterns/Images/thumbs/IMG_8681.webp"/>
+<div class="project-title">infrastructural public cisterns</div>
+</a>
+<a class="project-card" href="Casework in Munich/Casework in Munich.html">
+<img alt="Casework in Munich" data-fullres="Casework in Munich/Images/IMG_7122_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Casework in Munich/Images/thumbs/IMG_7122_Post.webp"/>
+<div class="project-title">Casework in Munich</div>
+</a>
+<a class="project-card" href="six_houses_two_walls/six_houses_two_walls.html">
+<img alt="six houses two walls" data-fullres="six_houses_two_walls/Images/250503_Small Lots Big Impacts_Diagram-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="six_houses_two_walls/Images/thumbs/250503_Small Lots Big Impacts_Diagram-03.webp"/>
+<div class="project-title">six houses two walls</div>
+</a>
+<a class="project-card" href="non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html">
+<img alt="non-planar printed ceramic studio" data-fullres="non-planar_printed_ceramic_studio/Images/Ceramic Studio Drawings-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="non-planar_printed_ceramic_studio/Images/thumbs/Ceramic Studio Drawings-03.webp"/>
+<div class="project-title">non-planar printed ceramic studio</div>
+</a>
+<a class="project-card" href="3247/3247.html">
+<img alt="3247" data-fullres="3247/Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="3247/Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.webp"/>
+<div class="project-title">3247</div>
+</a>
+<a class="project-card" href="DU OCTA PLEX/DU OCTA PLEX.html">
+<img alt="DU OCTA PLEX" data-fullres="DU OCTA PLEX/Images/DSCF8996_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="DU OCTA PLEX/Images/thumbs/DSCF8996_Edited.webp"/>
+<div class="project-title">DU OCTA PLEX</div>
+</a>
+<a class="project-card" href="space_arboretum/space_arboretum.html">
+<img alt="space arboretum" data-fullres="space_arboretum/Images/Arboretum Final_Roof Plan_BW-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="space_arboretum/Images/thumbs/Arboretum Final_Roof Plan_BW-01.webp"/>
+<div class="project-title">space arboretum</div>
+</a>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/comprehensive_studio/comprehensive_studio.html
+++ b/Projects/comprehensive_studio/comprehensive_studio.html
@@ -1,360 +1,360 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <title>Comprehensive Studio</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>Comprehensive Studio</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>Comprehensive Studio</h2>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>Comprehensive Studio</h2>
 <p>This project explores architectural infrastructure and public spatial systems through digital and physical modeling, generative diagrams, and construction logic.</p>
-    <div class="project-section">
-      <img src="Images/+15mm_Interior_Color_Corrected_with_people.jpg" alt="Interior Color Corrected">
-      <div class="project-text">
-        <h3>Interior Color Corrected</h3>
-        <p>Interior rendering with post-processed color correction and human scale.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/+Tube_B-Art.jpg" alt="Tube B Art">
-      <div class="project-text">
-        <h3>Tube B Art</h3>
-        <p>Artistic representation of spatial circulation through Tube B.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/+_12mm_Interiorn_Middle_front_2-Reflections.jpg" alt="Interior Reflection">
-      <div class="project-text">
-        <h3>Interior Reflection</h3>
-        <p>Early reflection render from the middle front perspective.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/2501_414_Studio_Desk_Critique_250203.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final-01.jpg" alt="Building Sections Semi Final">
-      <div class="project-text">
-        <h3>Building Sections Semi Final</h3>
-        <p>Finalized sectional studies showcasing structure and circulation.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/2501_Floor_Plans_Final_Page_1.jpg" alt="Floor Plan Page 1">
-      <div class="project-text">
-        <h3>Floor Plan Page 1</h3>
-        <p>Comprehensive floor plan layout for the first level.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/2501_Floor_Plans_Final_Page_3.jpg" alt="Floor Plan Page 3">
-      <div class="project-text">
-        <h3>Floor Plan Page 3</h3>
-        <p>Detailed floor plan layout for the third level.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250204_Foam_Model_Ink_Cros_Sections.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250204_Foam_Model_Plans.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250204_Foam_Model_Sections.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250223_Pin_Up_Massing_Model.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250317_Rhino_Render_Final.jpg" alt="Rhino Render Final">
-      <div class="project-text">
-        <h3>Rhino Render Final</h3>
-        <p>Final Rhino render demonstrating materials and lighting.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/A.UD_414-415_Massing_Model_Diagram_5.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Diagram_Roof.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Diagram_RoofSection_AnglesRadii-01.jpg" alt="Roof Section Diagram">
-      <div class="project-text">
-        <h3>Roof Section Diagram</h3>
-        <p>Diagram analyzing roof angles and radii.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_04482990-1b82-4486-8e4a-e8c37a15d006.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_3949ac89-0551-4a16-ba2f-cd5520a4fb09.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_42e90555-c78e-40dc-a303-b9190ac8c816.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_4330cbd8-eb0a-4a13-b74d-d9e6df250a31.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_526fd00f-5ab4-4fdb-b25d-b158f08d2e97.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_69bbbc08-87f3-48a1-a4ac-307e155d6d4f.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_6a7cc94d-dbc9-446b-85ef-d6ecbb1d3fe6.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_a8bfd3cd-03d0-41d8-85b5-f0b2e1fc1968.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_b48185fb-6191-44ce-89ea-0d7fa03f947c.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_f4635cbb-d2f5-4ff7-8308-c9e666b12f06.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Lincoln_Front_-_no_trees_Base.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-07.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-08.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-09.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-10.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-11.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-12.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-13.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-14.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-15.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-LN-04.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-00.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-03.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-12.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Plans_for_mid_final_review_Post_Review.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Screenshot_2025-02-05_122530.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Section-to_be_edited_gray.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Section_Diagrams_2.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Sections_for_mid_final_review.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Shear_Diagram.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Tube_A.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Tube_C.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/conceptual_image_929d9f6a-c61f-4bca-9f0b-df6f311990cf.jpeg" alt="Conceptual Image 1">
-      <div class="project-text">
-        <h3>Conceptual Image 1</h3>
-        <p>Conceptual image exploring form and space.</p>
-      </div>
-    </div>
-  </main>
+<div class="project-section">
+<img alt="Interior Color Corrected" data-fullres="Images/+15mm_Interior_Color_Corrected_with_people.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/+15mm_Interior_Color_Corrected_with_people.webp"/>
+<div class="project-text">
+<h3>Interior Color Corrected</h3>
+<p>Interior rendering with post-processed color correction and human scale.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Tube B Art" data-fullres="Images/+Tube_B-Art.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/+Tube_B-Art.webp"/>
+<div class="project-text">
+<h3>Tube B Art</h3>
+<p>Artistic representation of spatial circulation through Tube B.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Interior Reflection" data-fullres="Images/+_12mm_Interiorn_Middle_front_2-Reflections.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/+_12mm_Interiorn_Middle_front_2-Reflections.webp"/>
+<div class="project-text">
+<h3>Interior Reflection</h3>
+<p>Early reflection render from the middle front perspective.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/2501_414_Studio_Desk_Critique_250203.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/2501_414_Studio_Desk_Critique_250203.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Building Sections Semi Final" data-fullres="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/2501_Comprehensive_Studio_Building_Sections_Semi_Final-01.webp"/>
+<div class="project-text">
+<h3>Building Sections Semi Final</h3>
+<p>Finalized sectional studies showcasing structure and circulation.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Floor Plan Page 1" data-fullres="Images/2501_Floor_Plans_Final_Page_1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/2501_Floor_Plans_Final_Page_1.webp"/>
+<div class="project-text">
+<h3>Floor Plan Page 1</h3>
+<p>Comprehensive floor plan layout for the first level.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Floor Plan Page 3" data-fullres="Images/2501_Floor_Plans_Final_Page_3.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/2501_Floor_Plans_Final_Page_3.webp"/>
+<div class="project-text">
+<h3>Floor Plan Page 3</h3>
+<p>Detailed floor plan layout for the third level.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250204_Foam_Model_Ink_Cros_Sections.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250204_Foam_Model_Ink_Cros_Sections.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250204_Foam_Model_Plans.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250204_Foam_Model_Plans.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250204_Foam_Model_Sections.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250204_Foam_Model_Sections.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250223_Pin_Up_Massing_Model.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250223_Pin_Up_Massing_Model.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Rhino Render Final" data-fullres="Images/250317_Rhino_Render_Final.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250317_Rhino_Render_Final.webp"/>
+<div class="project-text">
+<h3>Rhino Render Final</h3>
+<p>Final Rhino render demonstrating materials and lighting.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/A.UD_414-415_Massing_Model_Diagram_5.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/A.UD_414-415_Massing_Model_Diagram_5.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Diagram_Roof.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Diagram_Roof.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Roof Section Diagram" data-fullres="Images/Diagram_RoofSection_AnglesRadii-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Diagram_RoofSection_AnglesRadii-01.webp"/>
+<div class="project-text">
+<h3>Roof Section Diagram</h3>
+<p>Diagram analyzing roof angles and radii.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_04482990-1b82-4486-8e4a-e8c37a15d006.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_04482990-1b82-4486-8e4a-e8c37a15d006.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_3949ac89-0551-4a16-ba2f-cd5520a4fb09.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_3949ac89-0551-4a16-ba2f-cd5520a4fb09.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_42e90555-c78e-40dc-a303-b9190ac8c816.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_42e90555-c78e-40dc-a303-b9190ac8c816.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_4330cbd8-eb0a-4a13-b74d-d9e6df250a31.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_4330cbd8-eb0a-4a13-b74d-d9e6df250a31.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_526fd00f-5ab4-4fdb-b25d-b158f08d2e97.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_526fd00f-5ab4-4fdb-b25d-b158f08d2e97.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_69bbbc08-87f3-48a1-a4ac-307e155d6d4f.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_69bbbc08-87f3-48a1-a4ac-307e155d6d4f.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_6a7cc94d-dbc9-446b-85ef-d6ecbb1d3fe6.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_6a7cc94d-dbc9-446b-85ef-d6ecbb1d3fe6.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_a8bfd3cd-03d0-41d8-85b5-f0b2e1fc1968.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_a8bfd3cd-03d0-41d8-85b5-f0b2e1fc1968.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_b48185fb-6191-44ce-89ea-0d7fa03f947c.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_b48185fb-6191-44ce-89ea-0d7fa03f947c.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_f4635cbb-d2f5-4ff7-8308-c9e666b12f06.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_f4635cbb-d2f5-4ff7-8308-c9e666b12f06.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Lincoln_Front_-_no_trees_Base.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Lincoln_Front_-_no_trees_Base.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-07.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-07.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-08.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-08.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-09.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-09.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-10.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-10.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-11.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-11.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-12.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-12.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-13.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-13.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-14.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-14.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-15.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-15.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-LN-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-LN-04.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-00.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-00.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-03.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-12.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-12.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Plans_for_mid_final_review_Post_Review.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Plans_for_mid_final_review_Post_Review.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Screenshot_2025-02-05_122530.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Screenshot_2025-02-05_122530.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Section-to_be_edited_gray.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section-to_be_edited_gray.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Section_Diagrams_2.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Section_Diagrams_2.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Sections_for_mid_final_review.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Sections_for_mid_final_review.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Shear_Diagram.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Shear_Diagram.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Tube_A.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Tube_A.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Tube_C.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Tube_C.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Conceptual Image 1" data-fullres="Images/conceptual_image_929d9f6a-c61f-4bca-9f0b-df6f311990cf.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/conceptual_image_929d9f6a-c61f-4bca-9f0b-df6f311990cf.webp"/>
+<div class="project-text">
+<h3>Conceptual Image 1</h3>
+<p>Conceptual image exploring form and space.</p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
+++ b/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
@@ -1,101 +1,100 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Infrastructural Public Cisterns</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>Infrastructural Public Cisterns</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>Infrastructural Public Cisterns</h2>
-
-    <div class="project-section">
-      <img src="Images/241207_Render Photography 1.5_Post Proccess.png" alt="Render Photography 1.5">
-      <div class="project-text">
-        <h3>Render Photography 1.5</h3>
-        <p>Post-processed rendering of the cistern site.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/241207_Render Photography 2_Post Proccess_Shadow.png" alt="Render Photography 2 with Shadow">
-      <div class="project-text">
-        <h3>Render Photography 2 with Shadow</h3>
-        <p>Second perspective render with emphasized shadows.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/DIAGRAMs.pdf" alt="Project Diagrams">
-      <div class="project-text">
-        <h3>Project Diagrams</h3>
-        <p>PDF compilation of conceptual and tectonic diagrams.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Enlarged Drawing-01-01.jpg" alt="Enlarged Drawing">
-      <div class="project-text">
-        <h3>Enlarged Drawing</h3>
-        <p>Detailed view of cistern assembly.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Floor Plan Iterations-02.jpg" alt="Floor Plan Iterations">
-      <div class="project-text">
-        <h3>Floor Plan Iterations</h3>
-        <p>Plan drawings comparing layout schemes.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Geological Diagram 1.jpg" alt="Geological Diagram">
-      <div class="project-text">
-        <h3>Geological Diagram</h3>
-        <p>Geological site section showing cistern location.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/IMG_7627.png" alt="Site Context Image 1">
-      <div class="project-text">
-        <h3>Site Context Image 1</h3>
-        <p>Photo documenting material conditions at site.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/IMG_7681.JPG" alt="Site Context Image 2">
-      <div class="project-text">
-        <h3>Site Context Image 2</h3>
-        <p>On-site photograph during early design phase.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/IMG_8681.png" alt="Water Entry Elevation">
-      <div class="project-text">
-        <h3>Water Entry Elevation</h3>
-        <p>Illustrates the entry sequence of the cistern.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" alt="Final Board Layout">
-      <div class="project-text">
-        <h3>Final Board Layout</h3>
-        <p>Rendered final board showing full project presentation.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Section 1_240712_Final Links to Indesign-01-01.jpg" alt="Section 1 Drawing">
-      <div class="project-text">
-        <h3>Section 1 Drawing</h3>
-        <p>Final section drawing exported from InDesign.</p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Section 3_240712_Final Links to Indesign-01-01-01-01-01.jpg" alt="Section 3 Drawing">
-      <div class="project-text">
-        <h3>Section 3 Drawing</h3>
-        <p>Compositional study of sectional moments.</p>
-      </div>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>Infrastructural Public Cisterns</h2>
+<div class="project-section">
+<img alt="Render Photography 1.5" data-fullres="Images/241207_Render Photography 1.5_Post Proccess.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/241207_Render Photography 1.5_Post Proccess.webp"/>
+<div class="project-text">
+<h3>Render Photography 1.5</h3>
+<p>Post-processed rendering of the cistern site.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Render Photography 2 with Shadow" data-fullres="Images/241207_Render Photography 2_Post Proccess_Shadow.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/241207_Render Photography 2_Post Proccess_Shadow.webp"/>
+<div class="project-text">
+<h3>Render Photography 2 with Shadow</h3>
+<p>Second perspective render with emphasized shadows.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Project Diagrams" data-fullres="Images/DIAGRAMs.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/DIAGRAMs.pdf"/>
+<div class="project-text">
+<h3>Project Diagrams</h3>
+<p>PDF compilation of conceptual and tectonic diagrams.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Enlarged Drawing" data-fullres="Images/Enlarged Drawing-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Enlarged Drawing-01-01.webp"/>
+<div class="project-text">
+<h3>Enlarged Drawing</h3>
+<p>Detailed view of cistern assembly.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Floor Plan Iterations" data-fullres="Images/Floor Plan Iterations-02.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Floor Plan Iterations-02.webp"/>
+<div class="project-text">
+<h3>Floor Plan Iterations</h3>
+<p>Plan drawings comparing layout schemes.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Geological Diagram" data-fullres="Images/Geological Diagram 1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Geological Diagram 1.webp"/>
+<div class="project-text">
+<h3>Geological Diagram</h3>
+<p>Geological site section showing cistern location.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Site Context Image 1" data-fullres="Images/IMG_7627.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7627.webp"/>
+<div class="project-text">
+<h3>Site Context Image 1</h3>
+<p>Photo documenting material conditions at site.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Site Context Image 2" data-fullres="Images/IMG_7681.JPG" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7681.webp"/>
+<div class="project-text">
+<h3>Site Context Image 2</h3>
+<p>On-site photograph during early design phase.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Water Entry Elevation" data-fullres="Images/IMG_8681.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_8681.webp"/>
+<div class="project-text">
+<h3>Water Entry Elevation</h3>
+<p>Illustrates the entry sequence of the cistern.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Final Board Layout" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.webp"/>
+<div class="project-text">
+<h3>Final Board Layout</h3>
+<p>Rendered final board showing full project presentation.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Section 1 Drawing" data-fullres="Images/Section 1_240712_Final Links to Indesign-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section 1_240712_Final Links to Indesign-01-01.webp"/>
+<div class="project-text">
+<h3>Section 1 Drawing</h3>
+<p>Final section drawing exported from InDesign.</p>
+</div>
+</div>
+<div class="project-section">
+<img alt="Section 3 Drawing" data-fullres="Images/Section 3_240712_Final Links to Indesign-01-01-01-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section 3_240712_Final Links to Indesign-01-01-01-01-01.webp"/>
+<div class="project-text">
+<h3>Section 3 Drawing</h3>
+<p>Compositional study of sectional moments.</p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html
+++ b/Projects/non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html
@@ -1,87 +1,86 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Non-Planar Printed Ceramic Studio</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>Non-Planar Printed Ceramic Studio</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>Non-Planar Printed Ceramic Studio</h2>
-
-    <div class="project-section">
-      <img src="Images/Ceramic Studio Drawings-03.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Ceramic Studio Drawings-04.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Ceramic Studio Drawings-05.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Ceramic Studio Drawings-06.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Ceramic Studio Drawings-07.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Ceramic Studio Drawings-08.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Diagram.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_0e4745b3-d9bd-46fa-963c-8ce5c5bba107.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_45eb4ad8-d2a5-49b8-bf04-a19dff4f55ab.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Storage_EMALEE.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>Non-Planar Printed Ceramic Studio</h2>
+<div class="project-section">
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-03.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-04.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-05.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-05.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-06.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-06.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-07.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-07.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-08.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-08.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Diagram.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Diagram.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_0e4745b3-d9bd-46fa-963c-8ce5c5bba107.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_0e4745b3-d9bd-46fa-963c-8ce5c5bba107.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_45eb4ad8-d2a5-49b8-bf04-a19dff4f55ab.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_45eb4ad8-d2a5-49b8-bf04-a19dff4f55ab.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Storage_EMALEE.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Storage_EMALEE.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/six_houses_two_walls/six_houses_two_walls.html
+++ b/Projects/six_houses_two_walls/six_houses_two_walls.html
@@ -1,101 +1,100 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Six Houses Two Walls</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>Six Houses Two Walls</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>Six Houses Two Walls</h2>
-
-    <div class="project-section">
-      <img src="Images/250503_Small Lots Big Impacts_Diagram-03.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250503_Small Lots Big Impacts_Diagram-04.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250503_Small Lots Big Impacts_Diagram-11.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250503_Small Lots Big Impacts_Diagram-18.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250504 Small Lots - Sections-01.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/250504 Small Lots - Sections-02.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/GenAIImage_ea98ffd4-07b6-46c7-b071-765f7b071d7a.jpeg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/IMG_5815.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/IMG_5824.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Small Lots Plans.pdf" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/image (3).jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/qr-code-71889614.png" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>Six Houses Two Walls</h2>
+<div class="project-section">
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-03.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-04.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-11.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-11.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-18.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-18.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250504 Small Lots - Sections-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250504 Small Lots - Sections-01.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/250504 Small Lots - Sections-02.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250504 Small Lots - Sections-02.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/GenAIImage_ea98ffd4-07b6-46c7-b071-765f7b071d7a.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_ea98ffd4-07b6-46c7-b071-765f7b071d7a.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/IMG_5815.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_5815.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/IMG_5824.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_5824.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Small Lots Plans.pdf" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Small Lots Plans.pdf"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/image (3).jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/image (3).webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/qr-code-71889614.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/qr-code-71889614.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/Projects/space_arboretum/space_arboretum.html
+++ b/Projects/space_arboretum/space_arboretum.html
@@ -1,59 +1,58 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Space Arboretum</title>
-  <link rel="stylesheet" href="../../H&dM.css" />
-  <script src="/repository/header.js" defer></script>
+<meta charset="utf-8"/>
+<title>Space Arboretum</title>
+<link href="../../H&amp;dM.css" rel="stylesheet"/>
+<script defer="" src="/repository/header.js"></script>
 </head>
 <body>
-  <div id="site-header"></div>
-
-    <main class="project-detail">
-    <h2>Space Arboretum</h2>
-
-    <div class="project-section">
-      <img src="Images/Arboretum Final_Roof Plan_BW-01.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-1.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-2_extended.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-4_Extended.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/Section_Post Class-01.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-    <div class="project-section">
-      <img src="Images/under.jpg" alt="">
-      <div class="project-text">
-        <h3></h3>
-        <p></p>
-      </div>
-    </div>
-  </main>
+<div id="site-header"></div>
+<main class="project-detail">
+<h2>Space Arboretum</h2>
+<div class="project-section">
+<img alt="" data-fullres="Images/Arboretum Final_Roof Plan_BW-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Arboretum Final_Roof Plan_BW-01.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-1.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-2_extended.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-2_extended.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-4_Extended.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-4_Extended.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/Section_Post Class-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section_Post Class-01.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+<div class="project-section">
+<img alt="" data-fullres="Images/under.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/under.webp"/>
+<div class="project-text">
+<h3></h3>
+<p></p>
+</div>
+</div>
+</main>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -94,7 +94,7 @@
           div.className = 'editable-section';
           div.setAttribute('draggable', true);
           div.innerHTML = `
-            <img src="${reader.result}" />
+            <img src="${reader.result}" loading="lazy" />
             <div>
               <input type="text" placeholder="Image Title" />
               <textarea placeholder="Description"></textarea>

--- a/optimize_images.py
+++ b/optimize_images.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Utility to generate webp thumbnails and update HTML image references.
+
+Creates a `thumbs/` directory inside every project `Images` folder and
+converts existing JPG/PNG files to WebP thumbnails with a maximum width of
+720 pixels. It can also rewrite HTML files so that `<img>` tags point to the
+new thumbnails, retain a `data-fullres` attribute for the original image and
+use lazy loading.
+
+Usage:
+    python optimize_images.py           # process images and update HTML
+    python optimize_images.py --images  # only process images
+    python optimize_images.py --html    # only update HTML files
+
+The script skips any image that already has a corresponding thumbnail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Iterable
+
+from PIL import Image
+from bs4 import BeautifulSoup
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png"}
+
+
+def create_thumbnail(src: Path, dest: Path, max_width: int = 720) -> None:
+    """Create a WebP thumbnail for *src* at *dest* with max width *max_width*.
+
+    Existing thumbnails are not overwritten.
+    """
+    if dest.exists():
+        return
+    try:
+        with Image.open(src) as img:
+            width, height = img.size
+            if width > max_width:
+                ratio = max_width / float(width)
+                img = img.resize((max_width, int(height * ratio)), Image.LANCZOS)
+            if img.mode in ("RGBA", "LA"):
+                img = img.convert("RGBA")
+            else:
+                img = img.convert("RGB")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            img.save(dest, "WEBP", quality=80)
+            print(f"Saved {dest}")
+    except Exception as exc:  # pragma: no cover - safety net
+        print(f"Failed to process {src}: {exc}")
+
+
+def generate_thumbnails(root: Path = Path("Projects")) -> None:
+    """Walk through *root* and create thumbnails for all images."""
+    for image_dir in (p for p in root.rglob("*") if p.is_dir() and p.name.lower() == "images"):
+        thumbs = image_dir / "thumbs"
+        thumbs.mkdir(exist_ok=True)
+        for file in image_dir.iterdir():
+            if file.is_file() and file.suffix.lower() in IMAGE_EXTS:
+                dest = thumbs / (file.stem + ".webp")
+                create_thumbnail(file, dest)
+
+
+def update_html(root: Path = Path(".")) -> None:
+    """Rewrite HTML files so that <img> tags use thumbnails.
+
+    The original image path is stored in `data-fullres` and used as a fallback
+    if the thumbnail is missing.
+    """
+    for html_file in (p for p in root.rglob("*.html")):
+        with html_file.open("r", encoding="utf-8") as f:
+            soup = BeautifulSoup(f, "html.parser")
+        changed = False
+        for img in soup.find_all("img"):
+            src = img.get("src")
+            if not src:
+                continue
+            img["loading"] = "lazy"
+            img["data-fullres"] = src
+            img["onerror"] = "this.onerror=null;this.src=this.dataset.fullres;"
+            ext = os.path.splitext(src)[1].lower()
+            if "thumbs/" in src or ext not in IMAGE_EXTS:
+                continue
+            parts = src.split("/")
+            try:
+                idx = next(i for i, part in enumerate(parts) if part.lower() == "images")
+            except StopIteration:
+                continue
+            thumb_src = "/".join(
+                parts[: idx + 1] + ["thumbs", Path(parts[-1]).stem + ".webp"]
+            )
+            img["src"] = thumb_src
+            changed = True
+        if changed:
+            with html_file.open("w", encoding="utf-8") as f:
+                f.write(str(soup))
+            print(f"Updated {html_file}")
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--images", action="store_true", help="only generate thumbnails"
+    )
+    parser.add_argument(
+        "--html", action="store_true", help="only update HTML references"
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if not args.images and not args.html:
+        args.images = args.html = True
+    if args.images:
+        generate_thumbnails()
+    if args.html:
+        update_html()

--- a/project-editor.js
+++ b/project-editor.js
@@ -33,8 +33,9 @@ function render() {
     section.className = 'project-section ' + (img.layout || '') + (isCover ? ' cover' : '');
     section.draggable = isAdmin;
     section.dataset.index = index;
+    const thumbName = img.filename.replace(/\.[^./]+$/, '.webp');
     section.innerHTML = `
-      <img class="lightbox-image" src="Images/${img.filename}" alt="${img.title}">
+      <img class="lightbox-image" src="Images/thumbs/${thumbName}" data-fullres="Images/${img.filename}" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" alt="${img.title}">
       <div class="project-text">
         <h3 contenteditable="${isAdmin}">${img.title}</h3>
         <p contenteditable="${isAdmin}">${img.description}</p>
@@ -143,16 +144,17 @@ function showLightbox(images, activeImage) {
   let currentIndex = images.indexOf(activeImage);
   const overlay = document.createElement('div');
   overlay.className = 'lightbox-overlay';
+  const fullSrc = activeImage.dataset.fullres || activeImage.src;
   overlay.innerHTML = `
     <span class="close">&times;</span>
     <span class="nav prev">&#10094;</span>
-    <img src="${activeImage.src}" />
+    <img src="${fullSrc}" loading="lazy" />
     <span class="nav next">&#10095;</span>
   `;
   document.body.appendChild(overlay);
   const overlayImg = overlay.querySelector('img');
   function update(idx) {
-    overlayImg.src = images[idx].src;
+    overlayImg.src = images[idx].dataset.fullres || images[idx].src;
     currentIndex = idx;
   }
   overlay.querySelector('.prev').onclick = () => update((currentIndex - 1 + images.length) % images.length);


### PR DESCRIPTION
## Summary
- Add `optimize_images.py` to generate 720px WebP thumbnails and rewrite HTML to use them
- Lazy-load images and keep full-resolution sources available for lightbox viewing
- Update project pages, dashboard previews, and editor lightbox to use thumbnail paths with fallback to originals

## Testing
- `python -m py_compile optimize_images.py`
- `python optimize_images.py --html`
- `node --check project-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_689187fb6a98832e9ba7218fe3607ad8