### PR TITLE
Fix project 3247 image paths

### DIFF
--- a/Projects/3247/3247.html
+++ b/Projects/3247/3247.html
@@ -12,28 +12,28 @@
 <main class="project-detail">
 <h2>32.47°</h2>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.webp"/>
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01-thumb.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.webp"/>
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02-thumb.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.webp"/>
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03-thumb.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Plan-01_Post Proccess-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Plan-01_Post Proccess-01.webp"/>
+<img alt="" data-fullres="Images/Plan-01_Post Proccess-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Plan-01_Post Proccess-01-thumb.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -32,7 +32,7 @@
 <div class="project-title">non-planar printed ceramic studio</div>
 </a>
 <a class="project-card" href="3247/3247.html">
-<img alt="3247" data-fullres="3247/Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="3247/Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.webp"/>
+<img alt="3247" data-fullres="3247/Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="3247/Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01-thumb.webp"/>
 <div class="project-title">3247</div>
 </a>
 <a class="project-card" href="DU OCTA PLEX/DU OCTA PLEX.html">


### PR DESCRIPTION
## Summary
- point project 3247 HTML to images in the main `Images` folder
- adjust Projects listing to match new thumbnail locations

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a198068c832e9761e7fb0465a576