### PR TITLE
Fix 3247 project images on GitHub Pages

### DIFF
--- a/Projects/3247/3247.html
+++ b/Projects/3247/3247.html
@@ -12,28 +12,28 @@
 <main class="project-detail">
 <h2>32.47°</h2>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01-thumb.webp"/>
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-01-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02-thumb.webp"/>
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-02-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03-thumb.webp"/>
+<img alt="" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Plan-01_Post Proccess-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Plan-01_Post Proccess-01-thumb.webp"/>
+<img alt="" data-fullres="Images/Plan-01_Post Proccess-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Plan-01_Post Proccess-01-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>

--- a/responsive-images.js
+++ b/responsive-images.js
@@ -56,6 +56,10 @@ function applyResponsiveImages(root = document) {
 }
 
 function initResponsiveImages() {
+  // Skip responsive image handling on static hosts like GitHub Pages
+  if (location.hostname.endsWith('github.io')) {
+    return;
+  }
   applyResponsiveImages();
 }
 


### PR DESCRIPTION
## Summary
- Skip responsive image resizing when running on static hosts like GitHub Pages
- Serve pre-generated medium WebP images for project 3247 to ensure fast, smooth loading

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6897d837b47c832eba03ef7361672873