### PR TITLE
Enable lightbox for high-resolution images

### DIFF
--- a/H&dM.css
+++ b/H&dM.css
@@ -292,6 +292,10 @@ body.editing .project-card {
   color: black;
 }
 
+img[data-fullres] {
+  cursor: pointer;
+}
+
 
 .lightbox-overlay {
   position: fixed;

--- a/dashboard.html
+++ b/dashboard.html
@@ -94,7 +94,7 @@
           div.className = 'editable-section';
           div.setAttribute('draggable', true);
           div.innerHTML = `
-            <img src="${reader.result}" loading="lazy" />
+            <img src="${reader.result}" data-fullres="${reader.result}" loading="lazy" />
             <div>
               <input type="text" placeholder="Image Title" />
               <textarea placeholder="Description"></textarea>

--- a/header.js
+++ b/header.js
@@ -31,6 +31,14 @@ if (!document.getElementById('responsive-images-script')) {
   document.head.appendChild(script);
 }
 
+if (!document.getElementById('lightbox-script')) {
+  const script = document.createElement('script');
+  script.src = '/repository/lightbox.js';
+  script.defer = true;
+  script.id = 'lightbox-script';
+  document.head.appendChild(script);
+}
+
 function initImageFadeIn(root = document) {
   const imgs = root.querySelectorAll('img');
   imgs.forEach(img => {

--- a/lightbox.js
+++ b/lightbox.js
@@ -1,0 +1,38 @@
+document.addEventListener('click', e => {
+  const images = Array.from(document.querySelectorAll('img[data-fullres]'));
+  if (images.includes(e.target)) {
+    showLightbox(images, e.target);
+  }
+});
+
+function showLightbox(images, activeImage) {
+  let currentIndex = images.indexOf(activeImage);
+  const overlay = document.createElement('div');
+  overlay.className = 'lightbox-overlay';
+  const fullSrc = activeImage.dataset.fullres || activeImage.src;
+  overlay.innerHTML = `
+    <span class="close">&times;</span>
+    <span class="nav prev">&#10094;</span>
+    <img src="${fullSrc}" loading="lazy" />
+    <span class="nav next">&#10095;</span>
+  `;
+  overlay.style.display = 'flex';
+  document.body.appendChild(overlay);
+  const overlayImg = overlay.querySelector('img');
+
+  function update(idx) {
+    overlayImg.src = images[idx].dataset.fullres || images[idx].src;
+    currentIndex = idx;
+  }
+
+  overlay.querySelector('.prev').onclick = () => update((currentIndex - 1 + images.length) % images.length);
+  overlay.querySelector('.next').onclick = () => update((currentIndex + 1) % images.length);
+  overlay.querySelector('.close').onclick = () => overlay.remove();
+  overlay.onclick = e => { if (e.target === overlay) overlay.remove(); };
+  document.onkeydown = e => {
+    if (e.key === 'Escape') overlay.remove();
+    if (e.key === 'ArrowLeft') overlay.querySelector('.prev').click();
+    if (e.key === 'ArrowRight') overlay.querySelector('.next').click();
+  };
+}
+


### PR DESCRIPTION
## Summary
- Load global lightbox script for images with `data-fullres`
- Add lightbox.js enabling click-to-zoom overlay navigation
- Mark high-res images as selectable with cursor styling and update dashboard preview markup

## Testing
- `node --check header.js`
- `node --check lightbox.js`


------
https://chatgpt.com/codex/tasks/task_e_689822b31aa8832e8151249a2f0d96f7