### PR TITLE
Prefer WebP images for projects

### DIFF
--- a/Projects/Casework in Munich/Casework in Munich.html
+++ b/Projects/Casework in Munich/Casework in Munich.html
@@ -12,14 +12,14 @@
 <main class="project-detail">
 <h2>Casework in Munich</h2>
 <div class="project-section">
-<img alt="" data-fullres="Images/IMG_7122_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7122_Post.webp"/>
+<img alt="" data-fullres="Images/IMG_7122_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/IMG_7122_Post-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/IMG_7126_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7126_Post.webp"/>
+<img alt="" data-fullres="Images/IMG_7126_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/IMG_7126_Post-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>

--- a/Projects/DU OCTA PLEX/DU OCTA PLEX.html
+++ b/Projects/DU OCTA PLEX/DU OCTA PLEX.html
@@ -12,56 +12,56 @@
 <main class="project-detail">
 <h2>DU OCTA PLEX</h2>
 <div class="project-section">
-<img alt="" data-fullres="Images/DSCF8996_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF8996_Edited.webp"/>
+<img alt="" data-fullres="Images/DSCF8996_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/DSCF8996_Edited-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/DSCF9010_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9010_Edited.webp"/>
+<img alt="" data-fullres="Images/DSCF9010_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/DSCF9010_Edited-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/DSCF9021_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9021_Edited.webp"/>
+<img alt="" data-fullres="Images/DSCF9021_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/DSCF9021_Edited-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/DSCF9070_Edits.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9070_Edits.webp"/>
+<img alt="" data-fullres="Images/DSCF9070_Edits.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/DSCF9070_Edits-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/DSCF9087_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/DSCF9087_Edited.webp"/>
+<img alt="" data-fullres="Images/DSCF9087_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/DSCF9087_Edited-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_056bae4b-05f4-4f98-9863-415a0695ff07.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_056bae4b-05f4-4f98-9863-415a0695ff07.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_056bae4b-05f4-4f98-9863-415a0695ff07.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_056bae4b-05f4-4f98-9863-415a0695ff07-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/qr-code-71889601.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/qr-code-71889601.webp"/>
+<img alt="" data-fullres="Images/qr-code-71889601.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/qr-code-71889601-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/qr-code-71889625.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/qr-code-71889625.webp"/>
+<img alt="" data-fullres="Images/qr-code-71889625.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/qr-code-71889625-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>

--- a/Projects/Projects.html
+++ b/Projects/Projects.html
@@ -12,23 +12,23 @@
 <main>
 <div class="projects-grid">
 <a class="project-card" href="comprehensive_studio/comprehensive_studio.html">
-<img alt="comprehensive studio" data-fullres="comprehensive_studio/Images/250317_Rhino_Render_Final.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="comprehensive_studio/Images/thumbs/250317_Rhino_Render_Final.webp"/>
+<img alt="comprehensive studio" data-fullres="comprehensive_studio/Images/250317_Rhino_Render_Final.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="comprehensive_studio/Images/250317_Rhino_Render_Final-thumb.webp"/>
 <div class="project-title">comprehensive studio</div>
 </a>
 <a class="project-card" href="infrastructural_public_cisterns/infrastructural_public_cisterns.html">
-<img alt="infrastructural public cisterns" data-fullres="infrastructural_public_cisterns/Images/IMG_8681.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="infrastructural_public_cisterns/Images/thumbs/IMG_8681.webp"/>
+<img alt="infrastructural public cisterns" data-fullres="infrastructural_public_cisterns/Images/IMG_8681.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="infrastructural_public_cisterns/Images/IMG_8681-thumb.webp"/>
 <div class="project-title">infrastructural public cisterns</div>
 </a>
 <a class="project-card" href="Casework in Munich/Casework in Munich.html">
-<img alt="Casework in Munich" data-fullres="Casework in Munich/Images/IMG_7122_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Casework in Munich/Images/thumbs/IMG_7122_Post.webp"/>
+<img alt="Casework in Munich" data-fullres="Casework in Munich/Images/IMG_7122_Post.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Casework in Munich/Images/IMG_7122_Post-thumb.webp"/>
 <div class="project-title">Casework in Munich</div>
 </a>
 <a class="project-card" href="six_houses_two_walls/six_houses_two_walls.html">
-<img alt="six houses two walls" data-fullres="six_houses_two_walls/Images/250503_Small Lots Big Impacts_Diagram-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="six_houses_two_walls/Images/thumbs/250503_Small Lots Big Impacts_Diagram-03.webp"/>
+<img alt="six houses two walls" data-fullres="six_houses_two_walls/Images/250503_Small Lots Big Impacts_Diagram-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="six_houses_two_walls/Images/250503_Small Lots Big Impacts_Diagram-03-thumb.webp"/>
 <div class="project-title">six houses two walls</div>
 </a>
 <a class="project-card" href="non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html">
-<img alt="non-planar printed ceramic studio" data-fullres="non-planar_printed_ceramic_studio/Images/Ceramic Studio Drawings-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="non-planar_printed_ceramic_studio/Images/thumbs/Ceramic Studio Drawings-03.webp"/>
+<img alt="non-planar printed ceramic studio" data-fullres="non-planar_printed_ceramic_studio/Images/Ceramic Studio Drawings-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="non-planar_printed_ceramic_studio/Images/Ceramic Studio Drawings-03-thumb.webp"/>
 <div class="project-title">non-planar printed ceramic studio</div>
 </a>
 <a class="project-card" href="3247/3247.html">
@@ -36,11 +36,11 @@
 <div class="project-title">3247</div>
 </a>
 <a class="project-card" href="DU OCTA PLEX/DU OCTA PLEX.html">
-<img alt="DU OCTA PLEX" data-fullres="DU OCTA PLEX/Images/DSCF8996_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="DU OCTA PLEX/Images/thumbs/DSCF8996_Edited.webp"/>
+<img alt="DU OCTA PLEX" data-fullres="DU OCTA PLEX/Images/DSCF8996_Edited.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="DU OCTA PLEX/Images/DSCF8996_Edited-thumb.webp"/>
 <div class="project-title">DU OCTA PLEX</div>
 </a>
 <a class="project-card" href="space_arboretum/space_arboretum.html">
-<img alt="space arboretum" data-fullres="space_arboretum/Images/Arboretum Final_Roof Plan_BW-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="space_arboretum/Images/thumbs/Arboretum Final_Roof Plan_BW-01.webp"/>
+<img alt="space arboretum" data-fullres="space_arboretum/Images/Arboretum Final_Roof Plan_BW-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="space_arboretum/Images/Arboretum Final_Roof Plan_BW-01-thumb.webp"/>
 <div class="project-title">space arboretum</div>
 </a>
 </div>

--- a/Projects/comprehensive_studio/comprehensive_studio.html
+++ b/Projects/comprehensive_studio/comprehensive_studio.html
@@ -13,21 +13,21 @@
 <h2>Comprehensive Studio</h2>
 <p>This project explores architectural infrastructure and public spatial systems through digital and physical modeling, generative diagrams, and construction logic.</p>
 <div class="project-section">
-<img alt="Interior Color Corrected" data-fullres="Images/+15mm_Interior_Color_Corrected_with_people.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/+15mm_Interior_Color_Corrected_with_people.webp"/>
+<img alt="Interior Color Corrected" data-fullres="Images/+15mm_Interior_Color_Corrected_with_people.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/+15mm_Interior_Color_Corrected_with_people-medium.webp"/>
 <div class="project-text">
 <h3>Interior Color Corrected</h3>
 <p>Interior rendering with post-processed color correction and human scale.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Tube B Art" data-fullres="Images/+Tube_B-Art.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/+Tube_B-Art.webp"/>
+<img alt="Tube B Art" data-fullres="Images/+Tube_B-Art.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/+Tube_B-Art-medium.webp"/>
 <div class="project-text">
 <h3>Tube B Art</h3>
 <p>Artistic representation of spatial circulation through Tube B.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Interior Reflection" data-fullres="Images/+_12mm_Interiorn_Middle_front_2-Reflections.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/+_12mm_Interiorn_Middle_front_2-Reflections.webp"/>
+<img alt="Interior Reflection" data-fullres="Images/+_12mm_Interiorn_Middle_front_2-Reflections.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/+_12mm_Interiorn_Middle_front_2-Reflections-medium.webp"/>
 <div class="project-text">
 <h3>Interior Reflection</h3>
 <p>Early reflection render from the middle front perspective.</p>
@@ -41,7 +41,7 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="Building Sections Semi Final" data-fullres="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/2501_Comprehensive_Studio_Building_Sections_Semi_Final-01.webp"/>
+<img alt="Building Sections Semi Final" data-fullres="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/2501_Comprehensive_Studio_Building_Sections_Semi_Final-01-medium.webp"/>
 <div class="project-text">
 <h3>Building Sections Semi Final</h3>
 <p>Finalized sectional studies showcasing structure and circulation.</p>
@@ -55,14 +55,14 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="Floor Plan Page 1" data-fullres="Images/2501_Floor_Plans_Final_Page_1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/2501_Floor_Plans_Final_Page_1.webp"/>
+<img alt="Floor Plan Page 1" data-fullres="Images/2501_Floor_Plans_Final_Page_1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/2501_Floor_Plans_Final_Page_1-medium.webp"/>
 <div class="project-text">
 <h3>Floor Plan Page 1</h3>
 <p>Comprehensive floor plan layout for the first level.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Floor Plan Page 3" data-fullres="Images/2501_Floor_Plans_Final_Page_3.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/2501_Floor_Plans_Final_Page_3.webp"/>
+<img alt="Floor Plan Page 3" data-fullres="Images/2501_Floor_Plans_Final_Page_3.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/2501_Floor_Plans_Final_Page_3-medium.webp"/>
 <div class="project-text">
 <h3>Floor Plan Page 3</h3>
 <p>Detailed floor plan layout for the third level.</p>
@@ -97,7 +97,7 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="Rhino Render Final" data-fullres="Images/250317_Rhino_Render_Final.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250317_Rhino_Render_Final.webp"/>
+<img alt="Rhino Render Final" data-fullres="Images/250317_Rhino_Render_Final.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250317_Rhino_Render_Final-medium.webp"/>
 <div class="project-text">
 <h3>Rhino Render Final</h3>
 <p>Final Rhino render demonstrating materials and lighting.</p>
@@ -118,175 +118,175 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="Roof Section Diagram" data-fullres="Images/Diagram_RoofSection_AnglesRadii-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Diagram_RoofSection_AnglesRadii-01.webp"/>
+<img alt="Roof Section Diagram" data-fullres="Images/Diagram_RoofSection_AnglesRadii-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Diagram_RoofSection_AnglesRadii-01-medium.webp"/>
 <div class="project-text">
 <h3>Roof Section Diagram</h3>
 <p>Diagram analyzing roof angles and radii.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_04482990-1b82-4486-8e4a-e8c37a15d006.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_04482990-1b82-4486-8e4a-e8c37a15d006.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_04482990-1b82-4486-8e4a-e8c37a15d006.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_04482990-1b82-4486-8e4a-e8c37a15d006-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_3949ac89-0551-4a16-ba2f-cd5520a4fb09.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_3949ac89-0551-4a16-ba2f-cd5520a4fb09.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_3949ac89-0551-4a16-ba2f-cd5520a4fb09.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_3949ac89-0551-4a16-ba2f-cd5520a4fb09-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_42e90555-c78e-40dc-a303-b9190ac8c816.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_42e90555-c78e-40dc-a303-b9190ac8c816.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_42e90555-c78e-40dc-a303-b9190ac8c816.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_42e90555-c78e-40dc-a303-b9190ac8c816-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_4330cbd8-eb0a-4a13-b74d-d9e6df250a31.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_4330cbd8-eb0a-4a13-b74d-d9e6df250a31.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_4330cbd8-eb0a-4a13-b74d-d9e6df250a31.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_4330cbd8-eb0a-4a13-b74d-d9e6df250a31-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_526fd00f-5ab4-4fdb-b25d-b158f08d2e97.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_526fd00f-5ab4-4fdb-b25d-b158f08d2e97.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_526fd00f-5ab4-4fdb-b25d-b158f08d2e97.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_526fd00f-5ab4-4fdb-b25d-b158f08d2e97-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_69bbbc08-87f3-48a1-a4ac-307e155d6d4f.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_69bbbc08-87f3-48a1-a4ac-307e155d6d4f.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_69bbbc08-87f3-48a1-a4ac-307e155d6d4f.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_69bbbc08-87f3-48a1-a4ac-307e155d6d4f-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_6a7cc94d-dbc9-446b-85ef-d6ecbb1d3fe6.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_6a7cc94d-dbc9-446b-85ef-d6ecbb1d3fe6.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_6a7cc94d-dbc9-446b-85ef-d6ecbb1d3fe6.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_6a7cc94d-dbc9-446b-85ef-d6ecbb1d3fe6-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_a8bfd3cd-03d0-41d8-85b5-f0b2e1fc1968.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_a8bfd3cd-03d0-41d8-85b5-f0b2e1fc1968.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_a8bfd3cd-03d0-41d8-85b5-f0b2e1fc1968.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_a8bfd3cd-03d0-41d8-85b5-f0b2e1fc1968-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_b48185fb-6191-44ce-89ea-0d7fa03f947c.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_b48185fb-6191-44ce-89ea-0d7fa03f947c.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_b48185fb-6191-44ce-89ea-0d7fa03f947c.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_b48185fb-6191-44ce-89ea-0d7fa03f947c-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_f4635cbb-d2f5-4ff7-8308-c9e666b12f06.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_f4635cbb-d2f5-4ff7-8308-c9e666b12f06.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_f4635cbb-d2f5-4ff7-8308-c9e666b12f06.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_f4635cbb-d2f5-4ff7-8308-c9e666b12f06-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Lincoln_Front_-_no_trees_Base.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Lincoln_Front_-_no_trees_Base.webp"/>
+<img alt="" data-fullres="Images/Lincoln_Front_-_no_trees_Base.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Lincoln_Front_-_no_trees_Base-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-07.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-07.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-07.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-07-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-08.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-08.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-08.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-08-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-09.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-09.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-09.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-09-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-10.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-10.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-10.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-10-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-11.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-11.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-11.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-11-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-12.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-12.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-12.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-12-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-13.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-13.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-13.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-13-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-14.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-14.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-14.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-14-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-15.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-15.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-15.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-DG-15-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-LN-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-LN-04.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-LN-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-LN-04-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-00.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-00.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-00.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-00-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-03.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-03-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-12.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-12.webp"/>
+<img alt="" data-fullres="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-12.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-S25-415.1-CDS-Ayata-Davidson-Emalee-Davidso-Nabil-RN-12-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
@@ -300,14 +300,14 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Screenshot_2025-02-05_122530.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Screenshot_2025-02-05_122530.webp"/>
+<img alt="" data-fullres="Images/Screenshot_2025-02-05_122530.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Screenshot_2025-02-05_122530-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Section-to_be_edited_gray.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section-to_be_edited_gray.webp"/>
+<img alt="" data-fullres="Images/Section-to_be_edited_gray.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Section-to_be_edited_gray-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
@@ -335,21 +335,21 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Tube_A.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Tube_A.webp"/>
+<img alt="" data-fullres="Images/Tube_A.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Tube_A-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Tube_C.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Tube_C.webp"/>
+<img alt="" data-fullres="Images/Tube_C.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Tube_C-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Conceptual Image 1" data-fullres="Images/conceptual_image_929d9f6a-c61f-4bca-9f0b-df6f311990cf.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/conceptual_image_929d9f6a-c61f-4bca-9f0b-df6f311990cf.webp"/>
+<img alt="Conceptual Image 1" data-fullres="Images/conceptual_image_929d9f6a-c61f-4bca-9f0b-df6f311990cf.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/conceptual_image_929d9f6a-c61f-4bca-9f0b-df6f311990cf-medium.webp"/>
 <div class="project-text">
 <h3>Conceptual Image 1</h3>
 <p>Conceptual image exploring form and space.</p>

--- a/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
+++ b/Projects/infrastructural_public_cisterns/infrastructural_public_cisterns.html
@@ -12,14 +12,14 @@
 <main class="project-detail">
 <h2>Infrastructural Public Cisterns</h2>
 <div class="project-section">
-<img alt="Render Photography 1.5" data-fullres="Images/241207_Render Photography 1.5_Post Proccess.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/241207_Render Photography 1.5_Post Proccess.webp"/>
+<img alt="Render Photography 1.5" data-fullres="Images/241207_Render Photography 1.5_Post Proccess.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/241207_Render Photography 1.5_Post Proccess-medium.webp"/>
 <div class="project-text">
 <h3>Render Photography 1.5</h3>
 <p>Post-processed rendering of the cistern site.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Render Photography 2 with Shadow" data-fullres="Images/241207_Render Photography 2_Post Proccess_Shadow.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/241207_Render Photography 2_Post Proccess_Shadow.webp"/>
+<img alt="Render Photography 2 with Shadow" data-fullres="Images/241207_Render Photography 2_Post Proccess_Shadow.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/241207_Render Photography 2_Post Proccess_Shadow-medium.webp"/>
 <div class="project-text">
 <h3>Render Photography 2 with Shadow</h3>
 <p>Second perspective render with emphasized shadows.</p>
@@ -33,63 +33,63 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="Enlarged Drawing" data-fullres="Images/Enlarged Drawing-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Enlarged Drawing-01-01.webp"/>
+<img alt="Enlarged Drawing" data-fullres="Images/Enlarged Drawing-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Enlarged Drawing-01-01-medium.webp"/>
 <div class="project-text">
 <h3>Enlarged Drawing</h3>
 <p>Detailed view of cistern assembly.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Floor Plan Iterations" data-fullres="Images/Floor Plan Iterations-02.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Floor Plan Iterations-02.webp"/>
+<img alt="Floor Plan Iterations" data-fullres="Images/Floor Plan Iterations-02.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Floor Plan Iterations-02-medium.webp"/>
 <div class="project-text">
 <h3>Floor Plan Iterations</h3>
 <p>Plan drawings comparing layout schemes.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Geological Diagram" data-fullres="Images/Geological Diagram 1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Geological Diagram 1.webp"/>
+<img alt="Geological Diagram" data-fullres="Images/Geological Diagram 1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Geological Diagram 1-medium.webp"/>
 <div class="project-text">
 <h3>Geological Diagram</h3>
 <p>Geological site section showing cistern location.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Site Context Image 1" data-fullres="Images/IMG_7627.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7627.webp"/>
+<img alt="Site Context Image 1" data-fullres="Images/IMG_7627.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/IMG_7627-medium.webp"/>
 <div class="project-text">
 <h3>Site Context Image 1</h3>
 <p>Photo documenting material conditions at site.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Site Context Image 2" data-fullres="Images/IMG_7681.JPG" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_7681.webp"/>
+<img alt="Site Context Image 2" data-fullres="Images/IMG_7681.JPG" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/IMG_7681-medium.webp"/>
 <div class="project-text">
 <h3>Site Context Image 2</h3>
 <p>On-site photograph during early design phase.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Water Entry Elevation" data-fullres="Images/IMG_8681.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_8681.webp"/>
+<img alt="Water Entry Elevation" data-fullres="Images/IMG_8681.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/IMG_8681-medium.webp"/>
 <div class="project-text">
 <h3>Water Entry Elevation</h3>
 <p>Illustrates the entry sequence of the cistern.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Final Board Layout" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.webp"/>
+<img alt="Final Board Layout" data-fullres="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-SP24-4011-TC-Feghali-Davidson-Nabil-RN-03-medium.webp"/>
 <div class="project-text">
 <h3>Final Board Layout</h3>
 <p>Rendered final board showing full project presentation.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Section 1 Drawing" data-fullres="Images/Section 1_240712_Final Links to Indesign-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section 1_240712_Final Links to Indesign-01-01.webp"/>
+<img alt="Section 1 Drawing" data-fullres="Images/Section 1_240712_Final Links to Indesign-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Section 1_240712_Final Links to Indesign-01-01-medium.webp"/>
 <div class="project-text">
 <h3>Section 1 Drawing</h3>
 <p>Final section drawing exported from InDesign.</p>
 </div>
 </div>
 <div class="project-section">
-<img alt="Section 3 Drawing" data-fullres="Images/Section 3_240712_Final Links to Indesign-01-01-01-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section 3_240712_Final Links to Indesign-01-01-01-01-01.webp"/>
+<img alt="Section 3 Drawing" data-fullres="Images/Section 3_240712_Final Links to Indesign-01-01-01-01-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Section 3_240712_Final Links to Indesign-01-01-01-01-01-medium.webp"/>
 <div class="project-text">
 <h3>Section 3 Drawing</h3>
 <p>Compositional study of sectional moments.</p>

--- a/Projects/non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html
+++ b/Projects/non-planar_printed_ceramic_studio/non-planar_printed_ceramic_studio.html
@@ -12,70 +12,70 @@
 <main class="project-detail">
 <h2>Non-Planar Printed Ceramic Studio</h2>
 <div class="project-section">
-<img alt="" data-fullres="Images/Ceramic Studio Drawings-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-03.webp"/>
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Ceramic Studio Drawings-03-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Ceramic Studio Drawings-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-04.webp"/>
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Ceramic Studio Drawings-04-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Ceramic Studio Drawings-05.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-05.webp"/>
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-05.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Ceramic Studio Drawings-05-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Ceramic Studio Drawings-06.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-06.webp"/>
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-06.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Ceramic Studio Drawings-06-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Ceramic Studio Drawings-07.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-07.webp"/>
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-07.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Ceramic Studio Drawings-07-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Ceramic Studio Drawings-08.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Ceramic Studio Drawings-08.webp"/>
+<img alt="" data-fullres="Images/Ceramic Studio Drawings-08.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Ceramic Studio Drawings-08-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Diagram.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Diagram.webp"/>
+<img alt="" data-fullres="Images/Diagram.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Diagram-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_0e4745b3-d9bd-46fa-963c-8ce5c5bba107.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_0e4745b3-d9bd-46fa-963c-8ce5c5bba107.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_0e4745b3-d9bd-46fa-963c-8ce5c5bba107.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_0e4745b3-d9bd-46fa-963c-8ce5c5bba107-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_45eb4ad8-d2a5-49b8-bf04-a19dff4f55ab.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_45eb4ad8-d2a5-49b8-bf04-a19dff4f55ab.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_45eb4ad8-d2a5-49b8-bf04-a19dff4f55ab.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_45eb4ad8-d2a5-49b8-bf04-a19dff4f55ab-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Storage_EMALEE.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Storage_EMALEE.webp"/>
+<img alt="" data-fullres="Images/Storage_EMALEE.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Storage_EMALEE-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>

--- a/Projects/six_houses_two_walls/six_houses_two_walls.html
+++ b/Projects/six_houses_two_walls/six_houses_two_walls.html
@@ -12,63 +12,63 @@
 <main class="project-detail">
 <h2>Six Houses Two Walls</h2>
 <div class="project-section">
-<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-03.webp"/>
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-03.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250503_Small Lots Big Impacts_Diagram-03-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-04.webp"/>
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-04.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250503_Small Lots Big Impacts_Diagram-04-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-11.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-11.webp"/>
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-11.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250503_Small Lots Big Impacts_Diagram-11-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-18.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250503_Small Lots Big Impacts_Diagram-18.webp"/>
+<img alt="" data-fullres="Images/250503_Small Lots Big Impacts_Diagram-18.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250503_Small Lots Big Impacts_Diagram-18-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/250504 Small Lots - Sections-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250504 Small Lots - Sections-01.webp"/>
+<img alt="" data-fullres="Images/250504 Small Lots - Sections-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250504 Small Lots - Sections-01-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/250504 Small Lots - Sections-02.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/250504 Small Lots - Sections-02.webp"/>
+<img alt="" data-fullres="Images/250504 Small Lots - Sections-02.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/250504 Small Lots - Sections-02-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/GenAIImage_ea98ffd4-07b6-46c7-b071-765f7b071d7a.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/GenAIImage_ea98ffd4-07b6-46c7-b071-765f7b071d7a.webp"/>
+<img alt="" data-fullres="Images/GenAIImage_ea98ffd4-07b6-46c7-b071-765f7b071d7a.jpeg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/GenAIImage_ea98ffd4-07b6-46c7-b071-765f7b071d7a-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/IMG_5815.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_5815.webp"/>
+<img alt="" data-fullres="Images/IMG_5815.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/IMG_5815-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/IMG_5824.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/IMG_5824.webp"/>
+<img alt="" data-fullres="Images/IMG_5824.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/IMG_5824-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
@@ -82,14 +82,14 @@
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/image (3).jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/image (3).webp"/>
+<img alt="" data-fullres="Images/image (3).jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/image (3)-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/qr-code-71889614.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/qr-code-71889614.webp"/>
+<img alt="" data-fullres="Images/qr-code-71889614.png" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/qr-code-71889614-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>

--- a/Projects/space_arboretum/space_arboretum.html
+++ b/Projects/space_arboretum/space_arboretum.html
@@ -12,42 +12,42 @@
 <main class="project-detail">
 <h2>Space Arboretum</h2>
 <div class="project-section">
-<img alt="" data-fullres="Images/Arboretum Final_Roof Plan_BW-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Arboretum Final_Roof Plan_BW-01.webp"/>
+<img alt="" data-fullres="Images/Arboretum Final_Roof Plan_BW-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Arboretum Final_Roof Plan_BW-01-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-1.webp"/>
+<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-1.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-1-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-2_extended.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-2_extended.webp"/>
+<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-2_extended.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-2_extended-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-4_Extended.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-4_Extended.webp"/>
+<img alt="" data-fullres="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-4_Extended.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/MArch-W24-412-TC-Freyinger-Davidson-Nabil-MD-4_Extended-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/Section_Post Class-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/Section_Post Class-01.webp"/>
+<img alt="" data-fullres="Images/Section_Post Class-01.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/Section_Post Class-01-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>
 </div>
 </div>
 <div class="project-section">
-<img alt="" data-fullres="Images/under.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/thumbs/under.webp"/>
+<img alt="" data-fullres="Images/under.jpg" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" src="Images/under-medium.webp"/>
 <div class="project-text">
 <h3></h3>
 <p></p>

--- a/project-editor.js
+++ b/project-editor.js
@@ -33,9 +33,10 @@ function render() {
     section.className = 'project-section ' + (img.layout || '') + (isCover ? ' cover' : '');
     section.draggable = isAdmin;
     section.dataset.index = index;
-    const thumbName = img.filename.replace(/\.[^./]+$/, '.webp');
+    const baseName = img.filename.replace(/\.[^./]+$/, '');
+    const mediumName = `${baseName}-medium.webp`;
     section.innerHTML = `
-      <img class="lightbox-image" src="Images/thumbs/${thumbName}" data-fullres="Images/${img.filename}" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" alt="${img.title}">
+      <img class="lightbox-image" src="Images/${mediumName}" data-fullres="Images/${img.filename}" loading="lazy" onerror="this.onerror=null;this.src=this.dataset.fullres;" alt="${img.title}">
       <div class="project-text">
         <h3 contenteditable="${isAdmin}">${img.title}</h3>
         <p contenteditable="${isAdmin}">${img.description}</p>


### PR DESCRIPTION
## Summary
- Serve medium-sized WebP images on project pages with original files as fallbacks
- Use WebP thumbnails on project listing
- Update editor to generate WebP paths for new uploads

## Testing
- `node --check project-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_6898280c4668832e8e16a464e2128a05